### PR TITLE
Crs workaround

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.0
+current_version = 1.3.0
 commit = True
 tag = True
 

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,4 @@ dmypy.json
 /oda_data/local_tests.py
 oda_data/get_data/sectors.py
 oda_data/dev_test.py
+oda_data/.raw_data/fullCRS.parquet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the oda_data package
 
+## [1.3.0] 2024-07-16
+* This release includes a workaround for the OECD bulk download service, which is down following the release of the new OECD website. The workaround uses a full CRS file shared by the OECD, which
+can take a long time to download, especially on slow connections (its nearly 1GB).
+
 ## [1.2] 2024-04-05
 * This release uses `oda_reader` to download data for DAC1 and DAC2a directly from the API.
 For now, the data is converted to the .Stat schema in order to ensure full backwards compatibility.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.abspath("../../oda_data/"))
 project = "oda_data"
 copyright = "2022, Jorge Rivera"
 author = "Jorge Rivera"
-release = "1.2.0"
+release = "1.3.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/oda_data/__init__.py
+++ b/oda_data/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 from oda_data import tools
 from oda_data.classes.oda_data import ODAData

--- a/oda_data/get_data/common.py
+++ b/oda_data/get_data/common.py
@@ -264,6 +264,9 @@ def _fetch_page_multiple_links(url: str) -> bs4.ResultSet:
     except requests.exceptions.SSLError:
         response = get_url_selenium(url).page_source
 
+    if len(response) == 0:
+        raise ConnectionError("Could not fetch page content. The page may be down")
+
     soup = BeautifulSoup(response, "html.parser")
     return soup.find_all("a")
 

--- a/oda_data/get_data/crs.py
+++ b/oda_data/get_data/crs.py
@@ -40,6 +40,48 @@ def _years(years: int | list | range, crs_dict: dict) -> list:
     return [y for y in years if y in crs_dict or y in range(1973, 2005)]
 
 
+def alternative_crs_download() -> None:
+    """Download the CRS data from an alternative source."""
+
+    from bs4 import BeautifulSoup
+
+    logger.info("Downloading CRS data from the alternative source...")
+
+    # Initial URL to the file on Google Drive
+    file_id = "1bgiSE5_bHPIjGuGggITNPScWgg2V4j2M"
+    file_url = f"https://drive.google.com/uc?export=download&id={file_id}"
+
+    # Session to persist cookies
+    session = requests.Session()
+
+    # Make a request to get the download warning page
+    response = session.get(file_url)
+    soup = BeautifulSoup(response.content, "html.parser")
+
+    # Find the confirmation token
+    confirm_token = soup.find("input", {"name": "confirm"})["value"]
+    uuid_token = soup.find("input", {"name": "uuid"})["value"]
+
+    # Generate the final download URL
+    download_url = (
+        f"https://drive.usercontent.google.com/download?id={file_id}&"
+        f"export=download&confirm={confirm_token}&uuid={uuid_token}"
+    )
+
+    # Make a request to download the file using the final download URL
+    response = session.get(download_url)
+
+    # Check if the request was successful
+    if response.status_code == 200:
+        # Open the local file in write-binary mode
+        with open(config.OdaPATHS.raw_data / "fullCRS.parquet", "wb") as file:
+            file.write(response.content)
+
+        logger.info("Full CRS data downloaded successfully.")
+    else:
+        logger.error("Failed to download the CRS data from the alternative source.")
+
+
 def download_crs(years: int | list | range, small_version: bool = False) -> None:
     """Download CRS files for the specified year(s) from the OECD and store
      them as feather files.
@@ -50,9 +92,20 @@ def download_crs(years: int | list | range, small_version: bool = False) -> None
         small_version: If True, only save a small version of the CRS data (default is False).
     """
 
-    crs_dict = common.extract_file_link_multiple(config.CRS_URL)
+    try:
+        crs_dict = common.extract_file_link_multiple(config.CRS_URL)
 
-    for year in _years(years, crs_dict):
-        year, name = resolve_crs_year_name(year)
-        df = _download(file_url=crs_dict[year], year=name)
-        _save(df=df, year=name, save_path=config.OdaPATHS.raw_data)
+        for year in _years(years, crs_dict):
+            year, name = resolve_crs_year_name(year)
+            df = _download(file_url=crs_dict[year], year=name)
+            _save(df=df, year=name, save_path=config.OdaPATHS.raw_data)
+
+    except ConnectionError:
+        logger.warning(
+            "Could not connect to the OECD website. The OECD"
+            "have released a new site which broke many of the data download"
+            "tools.\n The package will now try to fetch the data from a different repository"
+            "but this will take a long time. The provided file includes the full CRS and it is"
+            "almost 1GB in size."
+        )
+        alternative_crs_download()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oda_data"
-version = "1.2.0"
+version = "1.3.0"
 description = "A python package to work with Official Development Assistance data from the OECD DAC."
 readme = "README.md"
 authors = ["Jorge Rivera <jorge.rivera@one.org>"]


### PR DESCRIPTION
This PR adds a workaround given that the bulk download service is down (again!).
It relies on a full CRS parquet file shared by the OECD (current up to May 2024).

The download is really big (1GB). It will still try to use the bulk download service first just in case. Otherwise it will download it from our Google drive as a temporary measure.

Predicate pushdown is used to filter by year to avoid loading too much of the CRS at once.