### PR TITLE
Fix json validation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes to the oda_data package
 
+## [1.4.3] 2024-11-29
+* Fixes a json validation error for recipient groupings
+
 ## [1.4.2] 2024-11-26
 * Fixes donors and recipient groupings to fully align with recent schemas.
 

--- a/oda_data/settings/recipient_groupings.json
+++ b/oda_data/settings/recipient_groupings.json
@@ -470,7 +470,7 @@
     "1032": "Central America, regional",
     "1033": "Melanesia, regional",
     "1034": "Micronesia, regional",
-    "1035": "Polynesia, regional",
+    "1035": "Polynesia, regional"
 
   },
   "african_countries": {


### PR DESCRIPTION
This pull request includes a couple of changes aimed at fixing a json validation error and updating the changelog for the `oda_data` package.

### Changelog update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R5): Added a new entry for version 1.4.3, which includes a fix for a json validation error for recipient groupings.

### JSON validation fix:

* [`oda_data/settings/recipient_groupings.json`](diffhunk://#diff-84f15bfe72aee288c6d27c4c1453c663fff3a45380cc37f03cddb4de2e0d9bcbL473-R473): Corrected a minor formatting issue by ensuring the last entry in the json object does not have a trailing comma.