### PR TITLE
add gni shares

### DIFF
--- a/oda_data/__init__.py
+++ b/oda_data/__init__.py
@@ -7,6 +7,7 @@ from oda_data.api.main import Indicators
 from oda_data.api.sources import Dac1Data, Dac2aData, MultiSystemData, CrsData
 from oda_data.indicators.research.policy_markers import bilateral_policy_marker
 from oda_data.tools.compatibility import ODAData
+from oda_data.tools.gni import add_gni_share_column
 from oda_data.tools.groupings import donor_groupings, recipient_groupings
 from oda_data.tools.names.add import add_names_columns
 from oda_data.tools.sector_lists import add_sectors, add_broad_sectors
@@ -38,4 +39,5 @@ __all__ = [
     "set_data_path",
     "ODAData",
     "add_names_columns",
+    "add_gni_share_column",
 ]

--- a/oda_data/indicators/research/eu.py
+++ b/oda_data/indicators/research/eu.py
@@ -2,7 +2,6 @@
 
 import pandas as pd
 
-from oda_data import donor_groupings
 from oda_data.api.constants import Measure
 from oda_data.api.main import get_measure_filter, Indicators
 from oda_data.api.sources import Dac1Data
@@ -111,27 +110,27 @@ def get_eui_oda_weights(
 
 
 def get_eui_plus_bilateral_providers_indicator(
-    indicator_obj: Indicators, indicator: str | list[str]
+    indicators_obj: Indicators, indicator: str | list[str]
 ) -> pd.DataFrame:
     """Fetches indicator values with adjusted EU institution contributions.
 
     Args:
-        indicator_obj: An `Indicators` instance to fetch indicator data.
+        indicators_obj: An `Indicators` instance to fetch indicator data.
         indicator: Indicator code or list of codes.
 
     Returns:
         A DataFrame containing indicator values with adjusted EU contributions.
     """
     eui_weights = get_eui_oda_weights(
-        years=indicator_obj.years,
-        providers=indicator_obj.providers,
-        measure=indicator_obj.measure[0],
+        years=indicators_obj.years,
+        providers=indicators_obj.providers,
+        measure=indicators_obj.measure[0],
     )
 
-    if 918 not in indicator_obj.providers:
-        indicator_obj.providers.append(918)
+    if 918 not in indicators_obj.providers:
+        indicators_obj.providers.append(918)
 
-    data = indicator_obj.get_indicators(indicator)
+    data = indicators_obj.get_indicators(indicator)
     eui_mask = data[OdaSchema.PROVIDER_CODE] == 918
 
     data.loc[eui_mask, OdaSchema.VALUE] = data.loc[

--- a/oda_data/tools/gni.py
+++ b/oda_data/tools/gni.py
@@ -1,0 +1,93 @@
+"""Compute GNI share indicators, including EU Institutions if applicable."""
+
+from copy import copy
+import pandas as pd
+
+from oda_data import Indicators, donor_groupings
+from oda_data.clean_data.schema import OdaSchema
+
+
+def _get_eu27_gni_as_eu_institutions(gni_obj: Indicators) -> pd.DataFrame:
+    """Aggregate EU27 GNI and reassign it to EU Institutions (provider code 918).
+
+    Args:
+        gni_obj: An Indicators object configured to fetch GNI data.
+
+    Returns:
+        A DataFrame with the aggregated GNI for EU27, assigned to provider 918.
+    """
+    # Create a copy of the GNI object and set the providers to EU27 countries
+    eu27_obj = copy(gni_obj)
+    eu27_obj.providers = list(donor_groupings()["eu27_countries"])
+
+    # Fetch the data and set the provider code to 918 (EU Institutions)
+    df = eu27_obj.get_indicators("DAC1.40.1")
+    df[OdaSchema.PROVIDER_CODE] = 918
+    df[OdaSchema.PROVIDER_NAME] = "EU Institutions"
+
+    group_columns = [col for col in df.columns if col != OdaSchema.VALUE]
+
+    # Group by year and provider code, summing the GNI values
+    return (
+        df.groupby(group_columns, dropna=False, observed=True)[[OdaSchema.VALUE]]
+        .sum()
+        .reset_index()
+    )
+
+
+def _get_gni_data(indicators_obj: Indicators) -> pd.DataFrame:
+    """Fetch GNI data and optionally include EU Institutions' aggregate.
+
+    Args:
+        indicators_obj: An Indicators object for the main data context.
+
+    Returns:
+        A DataFrame with GNI values per provider and year.
+    """
+    # Create a copy of the indicators object and set the measure to "net_disbursement"
+    gni_obj = copy(indicators_obj)
+    gni_obj.measure = ["net_disbursement"]
+
+    # Fetch GNI data for the specified indicators
+    gni_df = gni_obj.get_indicators("DAC1.40.1")
+    providers = indicators_obj.providers or []
+
+    # Check if EU Institutions (provider code 918) is in the list of providers
+    # If it is, aggregate GNI for EU27 countries and assign it to provider 918
+    if 918 in providers or not providers:
+        eu_gni_df = _get_eu27_gni_as_eu_institutions(gni_obj)
+        gni_df = pd.concat([gni_df, eu_gni_df], ignore_index=True)
+
+    return gni_df.filter([OdaSchema.YEAR, OdaSchema.PROVIDER_CODE, OdaSchema.VALUE])
+
+
+def add_gni_share_column(
+    indicators_obj: Indicators, indicators: str | list[str]
+) -> pd.DataFrame:
+    """Add a GNI share column (%) to the dataset.
+
+    This function fetches GNI values per provider and year, merges them with the
+    indicator data, and computes each value's share of GNI.
+
+    Args:
+        indicators_obj: Configured Indicators object to fetch data.
+        indicators: A string or list of indicator codes to retrieve.
+
+    Returns:
+        A DataFrame with the original indicator data and a `gni_share_pct` column.
+    """
+    gni_data = _get_gni_data(indicators_obj)
+    indicator_data = indicators_obj.get_indicators(indicators)
+
+    merged = indicator_data.merge(
+        gni_data,
+        how="left",
+        on=[OdaSchema.YEAR, OdaSchema.PROVIDER_CODE],
+        suffixes=("", "_gni"),
+    )
+
+    merged["gni_share_pct"] = round(
+        100 * merged[OdaSchema.VALUE] / merged[f"{OdaSchema.VALUE}_gni"], 2
+    )
+
+    return merged


### PR DESCRIPTION
This PR introduces a new utility function, add_gni_share_column, which calculates each provider’s share of Gross National Income (GNI) for a given indicator. This is a common requirement when evaluating donor contributions relative to economic size, such as in assessing ODA/GNI ratios.

The tool works by fetching GNI values from the DAC1 dataset (DAC1.40.1) and merging them with the selected indicator(s) for a given set of providers and years. If the input includes EU Institutions (provider code 918), the tool also aggregates the GNI of EU27 member states and assigns it to the EU Institutions so that we can have an EU total GNI.

The resulting DataFrame includes a new column, gni_share_pct, which expresses the indicator value as a percentage of GNI.

```python
from oda_data import Indicators
from oda_data.tools.gni import add_gni_share_column

indicators = Indicators(
    years=range(2015, 2023),
    providers=[918, 302, 4],  # EU Institutions, US, France
    measure="net_disbursement",
)

df = add_gni_share_column(
    indicators_obj=indicators,
    indicators="DAC1.10.1010",  # e.g., total ODA
)

# df now includes a "gni_share_pct" column

```

@mharoruiz FYI