### PR TITLE
Naming tweaks

### DIFF
--- a/oda_data/__init__.py
+++ b/oda_data/__init__.py
@@ -20,7 +20,7 @@ def set_data_path(path):
     from pydeflate import set_pydeflate_path
 
     """Set the path to the data folder."""
-    global OdaPATHS
+    global ODAPaths
 
     ODAPaths.raw_data = Path(path).resolve()
     set_pydeflate_path(ODAPaths.raw_data)

--- a/oda_data/api/oecd.py
+++ b/oda_data/api/oecd.py
@@ -13,7 +13,7 @@ from oda_data.api.constants import (
     PRICES,
     _EXCLUDE,
 )
-from oda_data.api.representations import _OdaDict, _OdaList
+from oda_data.api.representations import _ODADict, _ODAList
 from oda_data.api.sources import DAC1Data, DAC2AData, CRSData, MultiSystemData
 from oda_data.clean_data import common as clean
 from oda_data.clean_data.validation import validate_currency, validate_measure
@@ -228,18 +228,18 @@ class OECDClient:
     def available_providers(cls) -> dict:
         """Returns a dictionary of available donor codes and their names"""
         logger.info("Note that not all providers may be available for all indicators")
-        return _OdaDict(provider_groupings()["all_official"])
+        return _ODADict(provider_groupings()["all_official"])
 
     @classmethod
     def available_recipients(cls) -> dict:
         """Returns a dictionary of available recipient codes"""
         logger.info("Note that not all recipients may be available for all indicators")
-        return _OdaDict(recipient_groupings()["all_developing_countries_regions"])
+        return _ODADict(recipient_groupings()["all_developing_countries_regions"])
 
     @classmethod
     def available_currencies(cls) -> list:
         """Returns a dictionary of available currencies"""
-        return _OdaList(CURRENCIES)
+        return _ODAList(CURRENCIES)
 
     @classmethod
     def available_indicators(cls) -> dict:
@@ -250,7 +250,7 @@ class OECDClient:
                 n: v for n, v in i.items() if n in ["name", "description", "sources"]
             }
 
-        return _OdaDict(indicators)
+        return _ODADict(indicators)
 
     @classmethod
     def export_available_indicators(cls, export_folder: str | Path) -> None:

--- a/oda_data/api/representations.py
+++ b/oda_data/api/representations.py
@@ -1,10 +1,10 @@
-class _OdaList(list):
+class _ODAList(list):
     def __repr__(self):
         # Return the elements with a line break between them
         return "[\n" + ",\n".join(str(x) for x in self) + "\n]"
 
 
-class _OdaDict(dict):
+class _ODADict(dict):
     def __repr__(self):
         # Return the elements with a line break between them
         return "{\n" + ",\n".join(f"{k}: {v}" for k, v in self.items()) + "\n}"

--- a/oda_data/indicators/research/eu.py
+++ b/oda_data/indicators/research/eu.py
@@ -115,28 +115,28 @@ def get_eui_oda_weights(
 
 
 def get_eui_plus_bilateral_providers_indicator(
-    indicators_obj: OECDClient, indicator: str | list[str]
+    client_obj: OECDClient, indicator: str | list[str]
 ) -> pd.DataFrame:
     """Fetches indicator values with adjusted EU institution contributions.
 
     Args:
-        indicators_obj: An `OECDClient` instance to fetch indicator data.
+        client_obj: An `OECDClient` instance to fetch indicator data.
         indicator: Indicator code or list of codes.
 
     Returns:
         A DataFrame containing indicator values with adjusted EU contributions.
     """
     eui_weights = get_eui_oda_weights(
-        years=indicators_obj.years,
-        providers=indicators_obj.providers,
-        measure=indicators_obj.measure[0],
-        use_bulk_download=indicators_obj.use_bulk_download,
+        years=client_obj.years,
+        providers=client_obj.providers,
+        measure=client_obj.measure[0],
+        use_bulk_download=client_obj.use_bulk_download,
     )
 
-    if 918 not in indicators_obj.providers:
-        indicators_obj.providers.append(918)
+    if 918 not in client_obj.providers:
+        client_obj.providers.append(918)
 
-    data = indicators_obj.get_indicators(indicator)
+    data = client_obj.get_indicators(indicator)
     eui_mask = data[ODASchema.PROVIDER_CODE] == 918
 
     data.loc[eui_mask, ODASchema.VALUE] = data.loc[


### PR DESCRIPTION
I made some minor changes to make sure the naming convention we settled on applied to the entire package. In particular, I renamed `_OdaList` and `_OdaDict` to `_ODAList` and `_ODADict`.

I also noticed that some functions in the `indicators/research` modules had a `indicator_obj` argument. Since the class is not called `Indicators` anymore, I though this could lead to confusion, so I renamed the argument to `client_obj`. 