### PR TITLE
[cache] Enable parquet cache for `oda-data`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ oda_data/dev_test.py
 oda_data/.raw_data/fullCRS.parquet
 /tutorials/data
 *.parquet
+oda_data/dev_tests.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes to the oda_data package
 
+## [2.0.1]
+- Improves caching performance by keeping a memory and disk cache of parquet files.
+
 ## [2.0.0]
 This major release is a complete refactoring of the `oda-data` package. It is now faster,
 more stable, and better organised.

--- a/oda_data/__init__.py
+++ b/oda_data/__init__.py
@@ -3,7 +3,7 @@ from importlib.metadata import version
 __version__ = version("oda_data")
 
 from oda_data import tools
-from oda_reader import set_cache_dir
+from oda_reader import set_cache_dir, disable_cache, enable_cache, clear_cache
 from oda_data.api.oecd import OECDClient
 from oda_data.api.sources import DAC1Data, DAC2AData, MultiSystemData, CRSData
 from oda_data.indicators.research.policy_markers import bilateral_policy_marker
@@ -43,4 +43,7 @@ __all__ = [
     "add_names_columns",
     "add_gni_share_column",
     "set_cache_dir",
+    "disable_cache",
+    "enable_cache",
+    "clear_cache",
 ]

--- a/oda_data/tools/cache.py
+++ b/oda_data/tools/cache.py
@@ -37,7 +37,7 @@ class OnDiskCache:
 
     def get_file_path(self, dataset_name: str, param_hash: str) -> Path:
         """Returns the on-disk path for the given dataset and parameter hash."""
-        return self.base_dir / f"filtered{dataset_name}-{param_hash}.parquet"
+        return self.base_dir / f"{dataset_name}-{param_hash}.parquet"
 
     def load(
         self,
@@ -65,9 +65,9 @@ class OnDiskCache:
 
     def cleanup(self, hash_str: Optional[str] = None, force: bool = False):
         """Removes expired cache files."""
-        pattern = f"filtered*{hash_str}*.parquet" if hash_str else "filtered*.parquet"
+        pattern = f"*{hash_str}*.parquet"
 
         for file in self.base_dir.glob(pattern):
             if self._is_expired(file) or force:
                 file.unlink(missing_ok=True)
-                logger.info(f"Deleted expired cache file: {file}")
+                logger.info(f"Deleted cache file: {file}")

--- a/poetry.lock
+++ b/poetry.lock
@@ -752,14 +752,14 @@ format-nongpl = ["fqdn", "idna", "isoduration", "jsonpointer (>1.13)", "rfc3339-
 
 [[package]]
 name = "jsonschema-specifications"
-version = "2024.10.1"
+version = "2025.4.1"
 description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "jsonschema_specifications-2024.10.1-py3-none-any.whl", hash = "sha256:a09a0680616357d9a0ecf05c12ad234479f549239d0f5b55f3deea67475da9bf"},
-    {file = "jsonschema_specifications-2024.10.1.tar.gz", hash = "sha256:0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272"},
+    {file = "jsonschema_specifications-2025.4.1-py3-none-any.whl", hash = "sha256:4653bffbd6584f7de83a67e0d620ef16900b390ddc7939d56684d6c81e33f1af"},
+    {file = "jsonschema_specifications-2025.4.1.tar.gz", hash = "sha256:630159c9f4dbea161a6a2205c3011cc4f18ff381b189fff48bb39b9bf26ae608"},
 ]
 
 [package.dependencies]
@@ -934,15 +934,15 @@ files = [
 
 [[package]]
 name = "mypy-extensions"
-version = "1.0.0"
+version = "1.1.0"
 description = "Type system extensions for programs checked with the mypy type checker."
 optional = true
-python-versions = ">=3.5"
+python-versions = ">=3.8"
 groups = ["main"]
 markers = "extra == \"dev\""
 files = [
-    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
-    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+    {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
+    {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
 ]
 
 [[package]]
@@ -1012,14 +1012,14 @@ files = [
 
 [[package]]
 name = "oda-reader"
-version = "1.1.3"
+version = "1.1.4"
 description = "A simple package to import ODA data using the OECD Data API"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "oda_reader-1.1.3-py3-none-any.whl", hash = "sha256:0c8b93d9039c528b488d20c09f29d479efc5df6c5e5e89f4cde27a30dc05691b"},
-    {file = "oda_reader-1.1.3.tar.gz", hash = "sha256:ae7305a81361c446516cab997e3938a218b8457556624accaf17a62df45ab7ab"},
+    {file = "oda_reader-1.1.4-py3-none-any.whl", hash = "sha256:d1d9e6455003845b838033504f7724bebdf3e7675057e524d0f7a8a3283da9b3"},
+    {file = "oda_reader-1.1.4.tar.gz", hash = "sha256:455ba42e2413fc1ebf4e7e080683d21514b18f19e837f6f16cfd538ff29382c5"},
 ]
 
 [package.dependencies]
@@ -2305,14 +2305,14 @@ files = [
 
 [[package]]
 name = "unidecode"
-version = "1.3.8"
+version = "1.4.0"
 description = "ASCII transliterations of Unicode text"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "Unidecode-1.3.8-py3-none-any.whl", hash = "sha256:d130a61ce6696f8148a3bd8fe779c99adeb4b870584eeb9526584e9aa091fd39"},
-    {file = "Unidecode-1.3.8.tar.gz", hash = "sha256:cfdb349d46ed3873ece4586b96aa75258726e2fa8ec21d6f00a591d98806c2f4"},
+    {file = "Unidecode-1.4.0-py3-none-any.whl", hash = "sha256:c3c7606c27503ad8d501270406e345ddb480a7b5f38827eafe4fa82a137f0021"},
+    {file = "Unidecode-1.4.0.tar.gz", hash = "sha256:ce35985008338b676573023acc382d62c264f307c8f7963733405add37ea2b23"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oda_data"
-version = "2.0.0"
+version = "2.0.1"
 description = "A python package to work with Official Development Assistance data from the OECD DAC."
 readme = "README.md"
 authors = [{ name = "Jorge Rivera", email = "jorge.rivera@one.org" }, { name = "Miguel Haro Ruiz", email = "miguel.haroruiz@one.org" }]


### PR DESCRIPTION
Besides the `oda-reader` cache of get requests, we also implement a memory and on-disk cache on the `oda-data` side in order to avoid very expensive unoptimised file reads.