### PR TITLE
add oda_gni

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes to the oda_data package
 
+## [2.0.2]
+- Adds functionality to calculate the official ODA/GNI.
+
 ## [2.0.1]
 - Improves caching performance by keeping a memory and disk cache of parquet files.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oda_data"
-version = "2.0.1"
+version = "2.0.2"
 description = "A python package to work with Official Development Assistance data from the OECD DAC."
 readme = "README.md"
 authors = [{ name = "Jorge Rivera", email = "jorge.rivera@one.org" }, { name = "Miguel Haro Ruiz", email = "miguel.haroruiz@one.org" }]


### PR DESCRIPTION
This pull request introduces a new feature to calculate the official ODA/GNI ratio, updates the package version to `2.0.2`, and documents the change in the `CHANGELOG.md`. Below are the key changes grouped by theme:

### New Feature: Official ODA/GNI Calculation
* Added a new function `official_oda_gni` in `oda_data/indicators/dac1/dac1_functions.py` to filter the dataset for Official Development Assistance (ODA) and compute the ratio of ODA to Gross National Income (GNI). 

### Documentation Updates
* Updated `CHANGELOG.md` to include details about the new functionality for calculating the official ODA/GNI ratio under version `2.0.2`.

### Versioning
* Updated the package version in `pyproject.toml` from `2.0.1` to `2.0.2` to reflect the addition of the new feature.