### PR TITLE
CRS research indicators default to bulk files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes to the oda_data package
 
+## [2.0.4]
+- Improvement: CRS research indicators use bulk downloads by default.
+
 ## [2.0.3]
 - Adds better bulk file memory management.
 

--- a/oda_data/indicators/research/policy_markers.py
+++ b/oda_data/indicators/research/policy_markers.py
@@ -100,7 +100,11 @@ def bilateral_policy_marker(
     crs = CRSData(providers=providers, years=years, recipients=recipients)
 
     # Read the data and group by provider and purpose
-    data = crs.read(columns=grouper + [measure], additional_filters=filters)
+    data = crs.read(
+        columns=grouper + [measure],
+        additional_filters=filters,
+        using_bulk_download=True,
+    )
 
     # if marker is not_screened, we need to filter out the screened data
     if marker == "not_screened":

--- a/oda_data/indicators/research/sector_imputations.py
+++ b/oda_data/indicators/research/sector_imputations.py
@@ -183,6 +183,7 @@ def spending_by_purpose(
         crs.read(
             columns=grouper + [measure],
             additional_filters=filters,
+            using_bulk_download=True,
         )
         .groupby(grouper, dropna=False, observed=True)[[measure]]
         .sum()
@@ -279,7 +280,11 @@ def core_multilateral_contributions_by_provider(
 
     # Read the data and group by provider and channel
     data = (
-        ms.read(columns=cols + [ODASchema.AMOUNT], additional_filters=filters)
+        ms.read(
+            columns=cols + [ODASchema.AMOUNT],
+            additional_filters=filters,
+            using_bulk_download=True,
+        )
         .groupby(cols, dropna=False, observed=True)[[ODASchema.AMOUNT]]
         .sum()
         .reset_index()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oda_data"
-version = "2.0.3"
+version = "2.0.4"
 description = "A python package to work with Official Development Assistance data from the OECD DAC."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
This pull request updates the `oda_data` package to version 2.0.4, introducing a key improvement where CRS research indicators now use bulk downloads by default. 

* [`oda_data/indicators/research/policy_markers.py`](diffhunk://#diff-dab7cd303911048a8f5a6933a48c8300b98561c4e50b61d4d9610468c2a8aad5L103-R107): Updated the `bilateral_policy_marker` function to use the `using_bulk_download=True` parameter in the `crs.read` method.
* [`oda_data/indicators/research/sector_imputations.py`](diffhunk://#diff-6b7f3374d4452b60eb612774b7308161ff67235d2397a97df99894bca443485bR186): Added the `using_bulk_download=True` parameter to the `spending_by_purpose` and `core_multilateral_contributions_by_provider` functions for improved data handling. [[1]](diffhunk://#diff-6b7f3374d4452b60eb612774b7308161ff67235d2397a97df99894bca443485bR186) [[2]](diffhunk://#diff-6b7f3374d4452b60eb612774b7308161ff67235d2397a97df99894bca443485bL282-R287)

### Version Update
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated the package version from 2.0.3 to 2.0.4 to reflect the new changes.

### Documentation Update
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R5): Added a new entry for version 2.0.4, highlighting the improvement to CRS research indicators.