### PR TITLE
Fix pascal case bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes to the oda_data package
 
+## [2.0.5]
+- Fixes a bug given that the Providers multisystem dataset uses a form of pascal case.
+
 ## [2.0.4]
 - Improvement: CRS research indicators use bulk downloads by default.
 

--- a/oda_data/tools/cache.py
+++ b/oda_data/tools/cache.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 import pandas as pd
 
 from oda_data.logger import logger
+from oda_data.tools.names.create_mapping import snake_to_pascal
 
 
 def generate_param_hash(filters: list[tuple]) -> str:
@@ -48,6 +49,13 @@ class OnDiskCache:
     ) -> pd.DataFrame | None:
         """Loads a DataFrame from disk if available and not expired."""
         path = self.get_file_path(dataset_name, param_hash)
+        if dataset_name == "MultiSystemData":
+            columns = [snake_to_pascal(col) for col in columns] if columns else columns
+            filters = (
+                [(snake_to_pascal(col), op, val) for col, op, val in filters]
+                if filters
+                else None
+            )
         if not path.exists():
             return None
         if self._is_expired(path):

--- a/oda_data/tools/names/create_mapping.py
+++ b/oda_data/tools/names/create_mapping.py
@@ -7,6 +7,38 @@ from oda_data.config import ODAPaths
 from oda_data.indicators.common import update_mapping_file
 
 
+def snake_to_pascal(name: str, *, keep_single_letter: bool = False) -> str:
+    """
+    Convert a snake_case string to PascalCase.
+
+    Parameters
+    ----------
+    name : str
+        The snake_case identifier to convert.
+    keep_single_letter : bool, default False
+        If True, preserve the underscore that precedes a 1-letter
+        segment (e.g. 'aid_t' → 'Aid_T').  If False, drop it
+        ('aid_t' → 'AidT').
+
+    Returns
+    -------
+    str
+        The PascalCase version.
+    """
+    parts = name.split("_")
+    if not keep_single_letter:
+        # Simple path: just capitalise everything and join.
+        return "".join(p.capitalize() for p in parts)
+
+    # Preserve “_” before any single-letter trailing part.
+    out: list[str] = []
+    for part in parts:
+        if len(part) == 1 and out:
+            out[-1] = out[-1] + "_" + part.upper()
+        else:
+            out.append(part.capitalize())
+    return "".join(out)
+
 def _code_name(df: pd.DataFrame, code_col: str, name_col: str) -> dict:
     """Return a dictionary mapping code to name."""
     return (


### PR DESCRIPTION
This PR addresses a bug in the `oda_data` package related to the handling of PascalCase column names in the Providers multisystem dataset. It includes a new utility function to convert snake_case to PascalCase and updates the caching logic to apply this transformation where needed.

### Bug Fixes:
* **PascalCase handling in multisystem dataset**: Fixed a bug where the Providers multisystem dataset required PascalCase column names. Updated the `load` method in `oda_data/tools/cache.py` to transform column names and filters to PascalCase when the dataset is "MultiSystemData."

### New Features:
* **`snake_to_pascal` utility function**: Added a new function `snake_to_pascal` in `oda_data/tools/names/create_mapping.py` to convert snake_case strings to PascalCase. It supports an optional parameter to preserve underscores before single-letter segments.

### Documentation:
* **Changelog update**: Updated `CHANGELOG.md` to include a note about the bug fix in version 2.0.5.

### Codebase Enhancements:
* **Imports**: Added the `snake_to_pascal` import to `oda_data/tools/cache.py` for use in the caching logic.