### PR TITLE
Fix constant prices multilateral imputations bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the oda_data package
 
+## [2.0.6]
+- Fixes a bug when trying to calculate
+multilateral imputations in constant prices
+
 ## [2.0.5]
 - Fixes a bug given that the Providers multisystem dataset uses a form of pascal case.
 

--- a/oda_data/api/sources.py
+++ b/oda_data/api/sources.py
@@ -26,6 +26,7 @@ from oda_data.clean_data.validation import (
     check_integers,
     check_strings,
 )
+from oda_data.config import ODAPaths
 from oda_data.logger import logger
 from oda_data.tools.cache import OnDiskCache, generate_param_hash
 
@@ -51,7 +52,7 @@ class Source:
     """
 
     memory_cache = TTLCache(maxsize=20, ttl=6000)
-    disk_cache = OnDiskCache(config.ODAPaths.raw_data, ttl_seconds=86400)
+    disk_cache = OnDiskCache(ODAPaths.raw_data, ttl_seconds=86400)
 
     def __init__(self):
         self.de_providers = None
@@ -91,7 +92,7 @@ class DACSource(Source):
     """
 
     memory_cache = TTLCache(maxsize=20, ttl=6000)
-    disk_cache = OnDiskCache(config.ODAPaths.raw_data, ttl_seconds=86400)
+    disk_cache = OnDiskCache(ODAPaths.raw_data, ttl_seconds=86400)
 
     def __init__(self):
         super().__init__()
@@ -521,7 +522,7 @@ class AidDataSource(Source):
     """
 
     memory_cache = TTLCache(maxsize=20, ttl=6000)
-    disk_cache = OnDiskCache(config.ODAPaths.raw_data, ttl_seconds=86400)
+    disk_cache = OnDiskCache(ODAPaths.raw_data, ttl_seconds=86400)
 
     def __init__(self):
         super().__init__()

--- a/oda_data/indicators/research/sector_imputations.py
+++ b/oda_data/indicators/research/sector_imputations.py
@@ -230,7 +230,7 @@ def multilateral_spending_shares_by_channel_and_purpose_smoothed(
         )
     )
 
-    return data.drop(columns=[ODASchema.VALUE])
+    return data.drop(columns=[ODASchema.VALUE, ODASchema.PRICES, ODASchema.CURRENCY])
 
 
 def core_multilateral_contributions_by_provider(
@@ -313,12 +313,7 @@ def _compute_imputations(
     # Merge core contributions with spending shares
     data = multi_spending_shares.merge(
         core_contributions,
-        on=[
-            ODASchema.CHANNEL_CODE,
-            ODASchema.YEAR,
-            ODASchema.CURRENCY,
-            ODASchema.PRICES,
-        ],
+        on=[ODASchema.CHANNEL_CODE, ODASchema.YEAR],
         how="inner",
     )
 

--- a/oda_data/tools/cache.py
+++ b/oda_data/tools/cache.py
@@ -2,7 +2,7 @@ import hashlib
 import json
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Optional
 
 import pandas as pd
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oda_data"
-version = "2.0.5"
+version = "2.0.6"
 description = "A python package to work with Official Development Assistance data from the OECD DAC."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
This PR fixes a bug in multilateral imputations

### Bug Fixes:
* Fixed a bug in the calculation of multilateral imputations in constant prices. When using constant prices, the flows and shares data wouldn't match in terms of currencies and prices.