### PR TITLE
[Fix] GNI in constant prices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changes to the oda_data package
+
+## [2.1.1]
+- Fixes a bug where GNI may not get converted to constant prices, even
+if a base year is specified.
+
 ## [2.1.0]
 - Improves AidDataData to behave more like other Sources.
 

--- a/oda_data/clean_data/common.py
+++ b/oda_data/clean_data/common.py
@@ -143,7 +143,9 @@ def convert_units(
     if indicator is None:
         indicator = ""
 
-    if ".40." in indicator or (currency == "USD" and base_year is None):
+    if ((".40." in indicator) and ("DAC1.40.1" != indicator)) or (
+        currency == "USD" and base_year is None
+    ):
         return data.assign(currency=currency, prices="current")
 
     elif base_year is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oda_data"
-version = "2.1.0"
+version = "2.1.1"
 description = "A python package to work with Official Development Assistance data from the OECD DAC."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
This pull request addresses a bug fix and version update for the `oda_data` package. 

### Bug Fixes:
* [`oda_data/clean_data/common.py`](diffhunk://#diff-c732813da6b1d3c08ac46a504d7b793ef2b9c5f7b7baf6ff9b2e60ace17ab12dL146-R148): Updated the `convert_units` function to exclude the indicator `DAC1.40.1` from a condition that previously applied to all indicators containing `.40.`. This resolves a bug where GNI may not get converted to constant prices even when a base year is specified.
