### PR TITLE
fix cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes to the oda_data package
 
+## [2.1.2]
+- Fixes caching paths to respect user-defined data directories and defaults to
+  a `.raw_data` folder relative to the working directory.
+
 ## [2.1.1]
 - Fixes a bug where GNI may not get converted to constant prices, even
 if a base year is specified.

--- a/oda_data/__init__.py
+++ b/oda_data/__init__.py
@@ -29,6 +29,7 @@ def set_data_path(path):
     global ODAPaths
 
     ODAPaths.raw_data = Path(path).resolve()
+    ODAPaths.pydeflate = ODAPaths.raw_data / ".pydeflate"
     set_pydeflate_path(ODAPaths.raw_data)
     set_cache_dir(ODAPaths.raw_data)
 

--- a/oda_data/__init__.py
+++ b/oda_data/__init__.py
@@ -29,6 +29,8 @@ def set_data_path(path):
     global ODAPaths
 
     ODAPaths.raw_data = Path(path).resolve()
+    # Create on explicit user request; avoids import-time side effects
+    ODAPaths.raw_data.mkdir(parents=True, exist_ok=True)
     ODAPaths.pydeflate = ODAPaths.raw_data / ".pydeflate"
     set_pydeflate_path(ODAPaths.raw_data)
     set_cache_dir(ODAPaths.raw_data)

--- a/oda_data/api/sources.py
+++ b/oda_data/api/sources.py
@@ -68,17 +68,19 @@ class Source:
 
     @property
     def disk_cache(self) -> OnDiskCache:
+        # Snapshot path to avoid inconsistency if it changes mid-check
+        current_raw = ODAPaths.raw_data
         # Fast-path without lock (shared, process-wide cache)
         dc = Source._shared_disk_cache
-        if dc is not None and dc.base_dir == ODAPaths.raw_data:
+        if dc is not None and dc.base_dir == current_raw:
             return dc
 
         # Slow-path with lock to ensure single initialization across threads
         with Source._shared_disk_cache_lock:
             dc = Source._shared_disk_cache
-            if dc is None or dc.base_dir != ODAPaths.raw_data:
+            if dc is None or dc.base_dir != current_raw:
                 Source._shared_disk_cache = OnDiskCache(
-                    ODAPaths.raw_data, ttl_seconds=86400
+                    current_raw, ttl_seconds=86400
                 )
             return Source._shared_disk_cache
 

--- a/oda_data/api/sources.py
+++ b/oda_data/api/sources.py
@@ -15,7 +15,6 @@ from oda_reader import (
 )
 from oda_reader._cache import memory
 
-from oda_data import config
 from oda_data.clean_data.common import (
     clean_raw_df,
     convert_dot_stat_to_data_explorer_codes,
@@ -52,9 +51,9 @@ class Source:
     """
 
     memory_cache = TTLCache(maxsize=20, ttl=6000)
-    disk_cache = OnDiskCache(ODAPaths.raw_data, ttl_seconds=86400)
 
     def __init__(self):
+        self._disk_cache = None
         self.de_providers = None
         self.de_recipients = None
         self.de_indicators = None
@@ -62,6 +61,15 @@ class Source:
         self.de_sectors = None
         self.schema = None
         self._param_hash = None
+
+    @property
+    def disk_cache(self) -> OnDiskCache:
+        if (
+            self._disk_cache is None
+            or self._disk_cache.base_dir != ODAPaths.raw_data
+        ):
+            self._disk_cache = OnDiskCache(ODAPaths.raw_data, ttl_seconds=86400)
+        return self._disk_cache
 
     def _add_filter(self, column: str, predicate: str, value: str | int | list) -> None:
         """Adds a filter to the dataset, ensuring no duplicate columns.
@@ -122,7 +130,6 @@ class DACSource(Source):
     """
 
     memory_cache = TTLCache(maxsize=20, ttl=6000)
-    disk_cache = OnDiskCache(ODAPaths.raw_data, ttl_seconds=86400)
 
     def __init__(self):
         super().__init__()
@@ -522,7 +529,6 @@ class AidDataSource(Source):
     """
 
     memory_cache = TTLCache(maxsize=20, ttl=6000)
-    disk_cache = OnDiskCache(ODAPaths.raw_data, ttl_seconds=86400)
 
     def __init__(self):
         super().__init__()
@@ -565,7 +571,6 @@ class AidDataData(AidDataSource):
     """Class to handle the AidData data."""
 
     memory_cache = TTLCache(maxsize=20, ttl=6000)
-    disk_cache = OnDiskCache(config.ODAPaths.raw_data, ttl_seconds=86400)
 
     def __init__(
         self,

--- a/oda_data/clean_data/common.py
+++ b/oda_data/clean_data/common.py
@@ -12,8 +12,6 @@ from oda_data.clean_data.validation import validate_currency
 from oda_data.config import ODAPaths
 from oda_data.logger import logger
 
-set_pydeflate_path(ODAPaths.raw_data)
-
 
 def clean_column_name(column_name: str) -> str:
     """Clean a column name by removing spaces, special characters, and lowercasing.
@@ -140,6 +138,14 @@ def convert_units(
     currency: str = "USD",
     base_year: Optional[int] = None,
 ):
+    # Ensure pydeflate has the current data path and directory exists (lazy init)
+    try:
+        ODAPaths.raw_data.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        # In read-only environments, let downstream functions surface meaningful errors
+        pass
+    set_pydeflate_path(ODAPaths.raw_data)
+
     if indicator is None:
         indicator = ""
 

--- a/oda_data/config.py
+++ b/oda_data/config.py
@@ -15,6 +15,3 @@ class ODAPaths:
     sectors = indicators / "sectors"
     tests = project / "tests"
     test_files = tests / "files"
-
-
-ODAPaths.raw_data.mkdir(parents=True, exist_ok=True)

--- a/oda_data/config.py
+++ b/oda_data/config.py
@@ -15,3 +15,6 @@ class ODAPaths:
     sectors = indicators / "sectors"
     tests = project / "tests"
     test_files = tests / "files"
+
+
+ODAPaths.raw_data.mkdir(parents=True, exist_ok=True)

--- a/oda_data/config.py
+++ b/oda_data/config.py
@@ -6,7 +6,7 @@ class ODAPaths:
 
     project = Path(__file__).resolve().parent.parent
     scripts = project / "oda_data"
-    raw_data = scripts / ".raw_data"
+    raw_data = (Path.cwd() / ".raw_data").resolve()
     pydeflate = raw_data / ".pydeflate"
     indicators = scripts / "indicators"
     names = scripts / "tools" / "names"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oda_data"
-version = "2.1.1"
+version = "2.1.2"
 description = "A python package to work with Official Development Assistance data from the OECD DAC."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
This pull request updates the `oda_data` package to version 2.1.2, focusing on improving how caching paths are handled to better respect user-defined data directories. The main changes involve refactoring cache initialization logic and updating default paths for raw data storage.

**Caching and data path improvements:**
* Changed the default `ODAPaths.raw_data` directory to use a `.raw_data` folder relative to the current working directory, making it easier for users to customize their data storage location.
* Updated cache initialization in the `Source` class and its subclasses to use a property-based approach for `disk_cache`, ensuring that the cache always points to the correct data directory and is re-initialized if the path changes (`oda_data/api/sources.py`).
* Modified `set_data_path` to set the `pydeflate` path relative to the new raw data directory (`oda_data/__init__.py`).
* Bumped package version to 2.1.2 in `pyproject.toml` to reflect these changes.