### PR TITLE
Improve caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the oda_data package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.2] - 2026-02-13
+
+### Fixed
+- Memory cache returning stale results when a cached DataFrame lacks columns requested by a subsequent query
+
 ## [2.4.1] - 2025-12-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oda_data"
-version = "2.4.1"
+version = "2.4.2"
 description = "A python package to work with Official Development Assistance data from the OECD DAC."
 requires-python = ">=3.11"
 

--- a/src/oda_data/api/sources.py
+++ b/src/oda_data/api/sources.py
@@ -37,6 +37,7 @@ from oda_data.tools.cache import (
     create_crs_bulk_fetcher,
     create_multisystem_bulk_fetcher,
     generate_param_hash,
+    generate_projection_hash,
 )
 
 
@@ -418,9 +419,20 @@ class DACSource(Source):
         # 1. Try memory cache (thread-safe, fastest)
         df = self.memory_cache.get(param_hash)
         if df is not None:
-            logger.info("Cache hit: memory")
-            # Data is already cleaned, just select columns if needed
-            return self._apply_columns_and_clean(df, columns, already_cleaned=True)
+            # Only use if all requested columns are available
+            if not columns or all(c in df.columns for c in columns):
+                logger.info("Cache hit: memory")
+                return self._apply_columns_and_clean(
+                    df, columns, already_cleaned=True
+                )
+
+        # For projected reads, also check a projection-specific memory cache
+        if columns:
+            proj_hash = generate_projection_hash(param_hash, columns)
+            df = self.memory_cache.get(proj_hash)
+            if df is not None:
+                logger.info("Cache hit: memory (projection)")
+                return df
 
         # 2. Try query cache (on-disk parquet, fast)
         df = self.query_cache.load(self.__class__.__name__, param_hash, None, columns)
@@ -435,9 +447,15 @@ class DACSource(Source):
 
         # 3. Cache miss (query/memory) - need to fetch data
         if using_bulk_download:
-            # Fetch from bulk cache with predicate pushdown and column selection
             logger.info("Query cache miss - reading from bulk cache")
             df = self._fetch_from_bulk_cache(filters, columns)
+            if columns:
+                # Cache projected result under a projection-specific key
+                # so it doesn't pollute the shared filter-only cache
+                self._cache_in_memory(
+                    generate_projection_hash(param_hash, columns), df
+                )
+                return df
         else:
             # Download via API (uses init-time filters only)
             logger.info("Cache miss - downloading via API")
@@ -801,9 +819,20 @@ class AidDataData(AidDataSource):
         # 1. Try memory cache
         df = self.memory_cache.get(param_hash)
         if df is not None:
-            logger.info("Cache hit: memory")
-            # Data is already cleaned, just select columns if needed
-            return self._apply_columns_and_clean(df, columns, already_cleaned=True)
+            # Only use if all requested columns are available
+            if not columns or all(c in df.columns for c in columns):
+                logger.info("Cache hit: memory")
+                return self._apply_columns_and_clean(
+                    df, columns, already_cleaned=True
+                )
+
+        # For projected reads, also check a projection-specific memory cache
+        if columns:
+            proj_hash = generate_projection_hash(param_hash, columns)
+            df = self.memory_cache.get(proj_hash)
+            if df is not None:
+                logger.info("Cache hit: memory (projection)")
+                return df
 
         # 2. Try query cache
         # Use column selection at parquet read level for efficiency
@@ -829,16 +858,19 @@ class AidDataData(AidDataSource):
         # Use PyArrow predicate pushdown and column selection for maximum efficiency
         pyarrow_filters = filters if filters else None
 
-        # If columns specified, read directly without caching (targeted read)
+        # If columns specified, read directly with projection-specific caching
         if columns:
             logger.info(
                 "Query cache miss - reading from bulk cache with column selection"
             )
-            # Targeted read: use full PyArrow optimization, no caching
             df = pd.read_parquet(
                 bulk_path, filters=pyarrow_filters, columns=columns, engine="pyarrow"
             )
-            # Data is already cleaned and column-selected, return directly
+            # Cache under projection-specific key to avoid polluting
+            # the shared filter-only cache
+            self._cache_in_memory(
+                generate_projection_hash(param_hash, columns), df
+            )
             return df
         else:
             logger.info("Query cache miss - reading from bulk cache")

--- a/src/oda_data/tools/cache.py
+++ b/src/oda_data/tools/cache.py
@@ -50,6 +50,25 @@ def generate_param_hash(filters: list[tuple]) -> str:
     return hashlib.md5(json_str.encode("utf-8")).hexdigest()[:10]
 
 
+def generate_projection_hash(param_hash: str, columns: list[str]) -> str:
+    """Generates a cache key for a projected (column-subset) read.
+
+    Combines the filter-based param_hash with a hash of the requested columns,
+    so that projected reads are cached separately from full reads without
+    polluting the shared filter-only cache key.
+
+    Args:
+        param_hash: The filter-only hash from generate_param_hash
+        columns: List of column names in the projection
+
+    Returns:
+        A combined hash string
+    """
+    col_str = json.dumps(sorted(columns), sort_keys=True)
+    col_hash = hashlib.md5(col_str.encode("utf-8")).hexdigest()[:10]
+    return f"{param_hash}_proj_{col_hash}"
+
+
 class ThreadSafeMemoryCache:
     """Thread-safe wrapper around cachetools.TTLCache.
 


### PR DESCRIPTION
This pull request addresses a bug in the memory cache logic that could return stale or incomplete results when a cached DataFrame did not contain all the columns requested by a subsequent query. The fix ensures that memory cache entries are only used if they include all requested columns, and introduces a projection-specific cache key to store and retrieve column-subset (projected) results separately. This prevents cache pollution and stale data issues for projected reads.

**Caching and Query Logic Improvements:**

* Updated the memory cache logic in `read` methods to only return a cached DataFrame if it contains all requested columns, preventing incomplete results from being served. [[1]](diffhunk://#diff-a4dfdeb3148850e23983fa53df33e1bfafab9acb76c99cca168d63aeba541c06R422-R435) [[2]](diffhunk://#diff-a4dfdeb3148850e23983fa53df33e1bfafab9acb76c99cca168d63aeba541c06R822-R835)
* Introduced a projection-specific cache key using the new `generate_projection_hash` function, allowing column-subset (projected) results to be cached and retrieved separately from full-table results. [[1]](diffhunk://#diff-e7390303e29f77914dd3a96960a4aac2950510a0b982b29e725bad116987f7a6R53-R71) [[2]](diffhunk://#diff-a4dfdeb3148850e23983fa53df33e1bfafab9acb76c99cca168d63aeba541c06R40)
* Modified bulk cache reads to cache projected DataFrames under their own keys, avoiding pollution of the main filter-based cache and ensuring correct results for future queries with the same projection. [[1]](diffhunk://#diff-a4dfdeb3148850e23983fa53df33e1bfafab9acb76c99cca168d63aeba541c06L438-R458) [[2]](diffhunk://#diff-a4dfdeb3148850e23983fa53df33e1bfafab9acb76c99cca168d63aeba541c06L832-R873)

**Documentation and Versioning:**

* Bumped the package version to `2.4.2` and updated the changelog to document the cache bug fix. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R12)