### PR TITLE
Caching improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,4 @@ dev_tests.py
 CLAUDE.md
 /.raw_data
 /src/oda_data/.raw_data
+/.claude

--- a/CACHING.md
+++ b/CACHING.md
@@ -1,0 +1,384 @@
+# Caching in oda_data
+
+This document covers how `oda_data` manages its cache from version 2.6 onward.
+For quick recovery commands, skip to [Recovery from a corrupt cache](#recovery-from-a-corrupt-cache).
+
+---
+
+## Overview
+
+Starting in `oda_data 2.6`, the cache layer is split along responsibility lines:
+
+- **`oda_reader`** owns the *raw bytes* layer: zip archives downloaded from the OECD
+  live in `oda_reader`'s raw cache.
+- **`oda_data`** owns the *cleaned parquet* layer: filtered, column-renamed DataFrames
+  ready for analysis live in `oda_data`'s bulk and query caches.
+
+Both layers are reachable through a single, version-stable public API at
+`oda_data.cache.*`. You do not need to interact with `oda_reader`'s cache directly
+unless you are a standalone `oda_reader` user (see
+[Standalone oda_reader users](#standalone-oda_reader-users)).
+
+---
+
+## Cache locations per OS
+
+The default cache root is determined by
+[`platformdirs`](https://github.com/platformdirs/platformdirs) and is
+version-segmented so that installs of different `oda_data` versions use separate
+directories automatically.
+
+| OS      | Default cache root                                                               |
+|---------|----------------------------------------------------------------------------------|
+| macOS   | `~/Library/Caches/oda-data/<version>/`                                           |
+| Linux   | `~/.cache/oda-data/<version>/`                                                   |
+| Windows | `C:\Users\<user>\AppData\Local\oda-data\oda-data\Cache\<version>\`               |
+
+Inside that root, four subdirectories hold the respective cache scopes:
+
+| Subdirectory  | Scope     | Contents                                         |
+|---------------|-----------|--------------------------------------------------|
+| `bulk_cache/` | `bulk`    | Cleaned parquet files extracted from OECD zips   |
+| `query_cache/`| `query`   | Filter-specific parquet slices                   |
+| `http/`       | `http`    | HTTP-level response cache (managed by oda_reader)|
+| `raw/`        | `raw`     | Raw OECD zip archives (managed by oda_reader)    |
+
+---
+
+## Configuring the cache root
+
+### Environment variable
+
+Set `ODA_DATA_CACHE_DIR` before starting Python (or before the first cache-touching
+call in a session) to override the default location:
+
+```bash
+export ODA_DATA_CACHE_DIR=/data/shared/oda-cache
+```
+
+### Python API
+
+```python
+import oda_data
+
+oda_data.set_cache_root("/data/shared/oda-cache")
+```
+
+`set_cache_root` takes priority over `ODA_DATA_CACHE_DIR`. Both are respected lazily
+on the first cache access, so they work even if called after `import oda_data`.
+
+### Note on `set_data_path`
+
+`set_data_path()` governs only *data outputs* (parquet exports) as of 2.6. It no
+longer controls the cache location. Calling it emits a one-time `DeprecationWarning`
+pointing at `set_cache_root` and `ODA_DATA_CACHE_DIR`. The shim is preserved through
+`oda_data 2.x` and removed in `3.0`.
+
+---
+
+## The Python API
+
+All public cache operations live under `oda_data.cache`. Import the namespace once
+and call functions directly:
+
+```python
+from oda_data import cache
+```
+
+`Scope` is one of `"all"`, `"bulk"`, `"query"`, `"http"`, `"raw"`. Every function
+that accepts a `scope` argument raises `ValueError` for unknown values.
+
+### `cache.path(scope="all") -> Path`
+
+Return the cache root directory, or the subdirectory for a specific scope.
+
+```python
+cache.path()          # e.g. ~/Library/Caches/oda-data/2.6.0/
+cache.path("bulk")    # e.g. ~/Library/Caches/oda-data/2.6.0/oda-data/bulk_cache/
+cache.path("raw")     # e.g. ~/Library/Caches/oda-data/2.6.0/oda-reader/raw/
+```
+
+### `cache.entries() -> dict[Scope, list[CacheRecord]]`
+
+Return all cached files grouped by scope. Each `CacheRecord` has `key`, `path`,
+`size_bytes`, `age_days`, `version`, and `scope` fields.
+
+```python
+for scope, records in cache.entries().items():
+    for r in records:
+        print(r.scope, r.key, r.size_bytes, r.age_days)
+```
+
+`"all"` is never a key in the returned dict — only the four concrete scopes
+(`"bulk"`, `"query"`, `"http"`, `"raw"`) appear.
+
+### `cache.clear(scope="all", *, blocking=True) -> dict[Scope, int | None]`
+
+Delete cached files in the named scope. Returns the count of files deleted per
+scope. For the `"bulk"` and `"query"` scopes (which `oda_data` writes under a
+`FileLock`), the value is `None` if the scope was skipped because another process
+held the write lock and `blocking=False` was passed. The `"http"` and `"raw"`
+scopes always return an `int` — see the
+[Multi-process behavior](#multi-process-behavior) section for why.
+
+```python
+# Clear everything, waiting for any write lock (default):
+cache.clear()
+
+# Clear only the raw zip cache:
+cache.clear("raw")
+
+# Non-blocking: skip contended scopes instead of waiting:
+result = cache.clear("bulk", blocking=False)
+if result.get("bulk") is None:
+    print("bulk cache is busy — try again later")
+```
+
+The distinction between `0` (scope was reachable but empty) and `None` (scope was
+locked by another writer) is intentional; it applies only to the `"bulk"` and
+`"query"` scopes, which `oda_data` manages under a `FileLock`.
+
+### `cache.size() -> dict[Scope, int]`
+
+Return on-disk usage in bytes per scope (the four concrete scopes; not `"all"`).
+
+```python
+sizes = cache.size()
+for scope, nbytes in sizes.items():
+    print(f"{scope}: {nbytes / 2**20:.1f} MB")
+```
+
+As a side effect, if the combined size of the current cache root **and** any
+sibling version directories (caches from older `oda_data` installs) exceeds 5 GB,
+one `WARNING` is logged per process with a pointer to the older directories and the
+`cache.clear(scope="raw")` recovery hint.
+
+### `cache.invalidate(dataset: type[Source] | str) -> None`
+
+Remove bulk and query cache entries for a single dataset. The argument can be
+either the class itself or its name as an exact-match string (case-sensitive).
+Raises `ValueError` for unrecognised names.
+
+**Blocking semantics:** `cache.invalidate` acquires the bulk and query write locks
+(60-second timeout each) so the unlink sequence cannot race with concurrent writers.
+Do not call `cache.invalidate` from inside a `BulkCacheManager` or
+`QueryCacheManager` write context — the caller would deadlock against itself.
+On `filelock.Timeout`, retry after the current writer completes; persistent
+timeouts may require a manual `cache.clear()`.
+
+```python
+from oda_data import cache, CRSData
+
+# By class:
+cache.invalidate(CRSData)
+
+# By name string (exact, case-sensitive):
+cache.invalidate("CRSData")
+```
+
+### `cache.enable_cache(scope="all")` / `cache.disable_cache(scope="all")`
+
+Toggle caching for a specific scope, or all scopes at once. Disabling a scope
+causes reads to bypass the cache layer for that scope until it is re-enabled.
+Useful in tests or when disk space is constrained.
+
+```python
+cache.disable_cache("bulk")   # subsequent reads skip the bulk parquet cache
+# ... do work ...
+cache.enable_cache("bulk")    # restore normal behaviour
+```
+
+**Note:** `"http"` and `"raw"` share a single underlying enable/disable toggle
+managed by `oda_reader`. Enabling or disabling either scope toggles both: for
+example, `cache.disable_cache("http")` will also disable `"raw"`, and vice versa.
+`oda_data` mirrors this coupling in its own per-scope flags so `is_scope_enabled`
+reports a consistent state on both sides. To toggle only the `oda_data`-owned
+scopes without affecting `oda_reader`, use `"bulk"` or `"query"` explicitly.
+
+### `cache.migrate(*, force=False) -> list[MigrationResult]`
+
+Manually re-run migration from pre-2.6 cache layouts (normally triggered
+automatically on the first cache-touching call). Pass `force=True` to override
+the synced-drive guard. Returns one `MigrationResult` per detected source root.
+
+```python
+results = cache.migrate(force=True)
+for r in results:
+    print(r.source, r.status, r.files_moved, r.bytes_moved)
+```
+
+### Scope reference
+
+| Scope   | Owner        | What it holds                                                              |
+|---------|--------------|----------------------------------------------------------------------------|
+| `all`   | —            | Shorthand for every scope at once. Not a key in `entries()` or `size()`.  |
+| `bulk`  | `oda_data`   | Cleaned parquet files extracted from OECD bulk zips.                       |
+| `query` | `oda_data`   | Filter-specific parquet slices derived from bulk files.                    |
+| `http`  | `oda_reader` | HTTP-level response cache.                                                 |
+| `raw`   | `oda_reader` | Raw OECD zip archives before extraction.                                   |
+
+**Note:** `"http"` and `"raw"` are independent on disk but share a single
+enable/disable toggle (managed by `oda_reader`); see the
+`cache.enable_cache` / `cache.disable_cache` section below for the implications.
+
+When troubleshooting corrupt downloads, start with `cache.clear("raw")` — it
+removes the raw zip archives without touching the cleaned parquet files. Clearing
+`"bulk"` or `"query"` forces parquet re-extraction without re-downloading the
+underlying zip.
+
+### `read(refresh=True)` — per-call bypass
+
+Pass `refresh=True` to any dataset read call to bypass the bulk cache and
+re-download fresh data on that specific call. This is equivalent to calling
+`cache.invalidate(dataset)` before reading, but scoped to the single call and
+without permanently removing the cache entry.
+
+```python
+from oda_data import CRSData
+
+crs = CRSData(years=[2023])
+df = crs.read(using_bulk_download=True, refresh=True)
+```
+
+This works on all dataset classes: `CRSData`, `DAC1Data`, `DAC2AData`,
+`MultiSystemData`, and `AidDataData`.
+
+---
+
+## Migration from older versions
+
+On the first cache-touching call after upgrading to `oda_data 2.6`, the package
+automatically detects pre-2.6 cache trees in the following locations and migrates
+them to the new layout:
+
+- `<cwd>/.raw_data/` (the old CWD-relative default)
+- `~/Library/Caches/oda-reader/<old-version>/` (macOS)
+- `~/.cache/oda-reader/<old-version>/` (Linux)
+- `%LOCALAPPDATA%\oda-reader\Cache\` (Windows)
+
+Migration rules:
+
+- **Same-volume**: files are moved via `shutil.move` (fast, no extra disk space needed).
+- **Cross-volume**: files are copied with `shutil.copy2`, size-verified, then the
+  original is deleted. A progress message is logged because this can take several
+  minutes for large caches (~1 GB).
+- **Synced drive** (Dropbox, iCloud Drive, OneDrive): migration is skipped and a
+  clear message is logged. The old cache remains readable for that session. Run
+  `oda_data.cache.migrate(force=True)` in Python to override the guard.
+- **Disk full** (`errno 28`): migration is skipped and a `WARNING` is logged. Both
+  old and new locations are left intact.
+
+After a successful migration, a `.migrated_to` breadcrumb file is written at the
+old root containing the absolute new path. Running `oda_data 2.5.x` against a
+migrated tree will raise a `RuntimeError` directing you to upgrade.
+
+### Manual migration
+
+```python
+from oda_data import cache
+
+# Re-run migration with the synced-drive guard disabled:
+results = cache.migrate(force=True)
+for r in results:
+    print(r.source, r.status, r.files_moved, r.bytes_moved)
+```
+
+`cache.migrate()` returns a `list[MigrationResult]`, one per detected source root.
+Each `MigrationResult` has `source`, `status`, `files_moved`, `bytes_moved`, and
+`message` fields.
+
+---
+
+## Recovery from a corrupt cache
+
+If `oda_data` raises `BulkPayloadCorrupt` or you see stale/corrupt data, clear the
+raw cache and retry:
+
+```python
+from oda_data import cache, CRSData
+
+# Wipe the raw zip cache managed by oda_reader:
+cache.clear("raw")
+# Or wipe everything: cache.clear("all")
+
+# Re-read normally — the zip will be re-downloaded:
+df = CRSData(years=[2023]).read(using_bulk_download=True)
+```
+
+`BulkPayloadCorrupt` is raised when a freshly downloaded zip fails `is_zipfile()` or
+`ZipFile.testzip()` integrity checks. The exception carries `.path` (the corrupt
+file's location) and `.reason` (which check failed). `oda_data` automatically clears
+the bad entry and retries the download once; the exception only surfaces to the caller
+if both the original download and the retry fail.
+
+If you want to skip the raw cache entirely for a single call (useful when the network
+feed may be temporarily corrupt but you do not want to wipe the whole cache), pass
+`use_raw_cache=False` to the underlying `oda_reader` bulk functions directly, or call
+`read` with `refresh=True` to bypass at the `oda_data` level:
+
+```python
+# Skip the raw zip cache for this call only; no disk footprint, re-downloads every time:
+from oda_reader import bulk_download_crs
+bulk_download_crs(save_to_path="/tmp/crs", use_raw_cache=False)
+```
+
+---
+
+## Multi-process behavior
+
+`oda_data` uses `filelock.FileLock` to coordinate cache writes across processes.
+Concurrent reads are always safe because readers never hold a write lock.
+
+Write coordination:
+
+- **`BulkCacheManager`** acquires the lock before writing a new zip download. If
+  two notebooks start `crs.read(using_bulk_download=True)` at the same time, the
+  second blocks until the first completes and then reads from the already-written
+  cache entry — only one network download occurs.
+- **`cache.clear(blocking=True)`** (the default): acquires the lock and waits up
+  to 1200 s for any in-progress write to finish.
+- **`cache.clear(blocking=False)`**: skips scopes under contention instead of
+  blocking. Returns `None` for each contended `"bulk"` / `"query"` scope (rather
+  than `0`, which means the scope was reachable but empty). The `"http"` and
+  `"raw"` scopes always return an `int` — `oda_reader` does not expose a public
+  lock path for those caches, so contention cannot be detected; every reachable
+  file is unlinked unconditionally. This distinction matters when the caller
+  needs to confirm whether a clear was actually attempted.
+
+Crash recovery: if a process is SIGKILLed mid-write, the incomplete file is left
+at a `.tmp-<host>-<pid>` path. On the next `CacheManager` initialisation (which
+happens at the start of every read session), any `*.tmp-*` file with an mtime
+older than 24 hours is automatically removed. The `<host>` component in the suffix
+prevents PID collisions on NFS or other shared mounts across multiple machines.
+
+---
+
+## Standalone `oda_reader` users
+
+Users who import `oda_reader` directly without `oda_data` can continue to use the
+four legacy helpers unchanged:
+
+```python
+import oda_reader
+
+oda_reader.set_cache_dir("/my/cache")
+oda_reader.clear_cache()
+oda_reader.enable_cache()
+oda_reader.disable_cache()
+```
+
+These functions are fully functional and will not be removed until `oda_reader 2.0`.
+
+**If `oda_data` is also imported in the same process**, each of these functions emits
+a one-time `DeprecationWarning` (once per function per session) directing you to the
+equivalent `oda_data.cache.*` call:
+
+| Legacy call                         | `oda_data` equivalent                    |
+|-------------------------------------|------------------------------------------|
+| `oda_reader.set_cache_dir(path)`    | `oda_data.set_cache_root(path)`          |
+| `oda_reader.clear_cache()`          | `oda_data.cache.clear("all")`            |
+| `oda_reader.enable_cache()`         | `oda_data.cache.enable_cache("all")`     |
+| `oda_reader.disable_cache()`        | `oda_data.cache.disable_cache("all")`    |
+
+Standalone `oda_reader` users who do **not** also import `oda_data` will never see
+these warnings. The shims are preserved through `oda_reader 1.x` and removed in `2.0`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,71 @@ All notable changes to the oda_data package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - 2026-04-28
+
+This release reorganises how `oda_data` stores downloaded data on disk.
+Caches now live in a standard per-user location instead of inside your
+project folder, and a new `oda_data.cache.*` namespace gives you a clear,
+typed way to inspect and manage them. Existing caches are migrated
+automatically on first run. See [CACHING.md](CACHING.md) for the full
+walkthrough.
+
+### Added
+- **Per-user cache by default.** Downloads now live under your OS's standard
+  cache directory (`~/Library/Caches/oda-data/` on macOS, `~/.cache/oda-data/`
+  on Linux, `%LOCALAPPDATA%\oda-data\` on Windows), versioned per release.
+  This means cache is shared across projects instead of duplicated in every
+  `.raw_data/` folder, and old versions don't silently get re-used after an
+  upgrade.
+- **Override the cache location** with `oda_data.set_cache_root(path)` or the
+  `ODA_DATA_CACHE_DIR` environment variable — useful for shared volumes or
+  CI runners with limited home-directory space.
+- **One place to manage the cache: `oda_data.cache`.** Inspect what's cached,
+  clear specific parts, or invalidate a single dataset without touching the
+  rest:
+
+    ```python
+    from oda_data import cache, CRSData
+
+    cache.size()                # bytes per scope
+    cache.clear("raw")          # drop only raw OECD zips
+    cache.invalidate(CRSData)   # forget cached CRS, keep everything else
+    ```
+
+- **Per-call `refresh=True`** on every dataset's `read()` to force a fresh
+  download for one call without permanently clearing the cache.
+- **Automatic recovery from corrupt downloads.** When a freshly downloaded
+  zip fails its integrity check, the bad file is removed and the download is
+  retried once. If both attempts fail, you get a clear `BulkPayloadCorrupt`
+  error pointing at the file and the reason.
+
+### Changed
+- **`set_data_path()` no longer controls the cache.** It now only sets where
+  the package writes parquet *exports* (data you explicitly save out). If you
+  used it to redirect cache storage, switch to `set_cache_root()` or
+  `ODA_DATA_CACHE_DIR` — the package will print a one-time deprecation
+  warning to remind you. The old call still works through 2.x and is removed
+  in 3.0.
+- **`clear_cache()`, `enable_cache()`, and `disable_cache()` still work**
+  unchanged. They now delegate to the new `cache.*` namespace, so existing
+  scripts keep running without edits.
+
+### Migration
+On the first cache-touching call after upgrading, the package looks for
+pre-2.6 caches in their old locations (`./.raw_data/`, the per-OS
+`oda-reader` directory) and moves them into the new layout. Caches on
+synced drives (Dropbox, iCloud, OneDrive) are skipped with a clear log
+message — re-run with `oda_data.cache.migrate(force=True)` to override.
+
+## [2.5.1] - 2026-04-28
+
+### Fixed
+- OECD CRS bulk downloads using the newer PKZIP Deflate64 compression method
+  no longer fail with `BadZipFile: File is not a zip file`. Pulled in via
+  `oda-reader >= 1.5.1`. If you saw this error before upgrading, delete any
+  stale file under your `oda-reader` bulk cache (path varies by OS) before
+  retrying.
+
 ## [2.5.0] - 2026-04-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -417,20 +417,28 @@ dac_members = providers["dac_members"]
 
 ### Cache Management
 
-Control the package's caching behavior:
+`oda_data` stores downloaded data in a per-OS, version-segmented directory
+(`~/Library/Caches/oda-data/<version>/` on macOS, `~/.cache/oda-data/<version>/`
+on Linux, and the equivalent `AppData\Local` path on Windows). The location can be
+overridden with `oda_data.set_cache_root(path)` or the `ODA_DATA_CACHE_DIR`
+environment variable. See [CACHING.md](CACHING.md) for full details on disk
+locations, scopes, multi-process behavior, and migration from older versions.
+
+The fastest recovery path for a corrupt or stale cache is:
 
 ```python
-from oda_data import clear_cache, disable_cache, enable_cache
+from oda_data import cache
 
-# Clear all cached data
-clear_cache()
+# Clear only the raw zip archives and let them re-download on next read:
+cache.clear("raw")
 
-# Temporarily disable caching (for development/testing)
-disable_cache()
-
-# Re-enable caching
-enable_cache()
+# Or wipe everything:
+cache.clear("all")
 ```
+
+The legacy helpers `clear_cache()`, `disable_cache()`, and `enable_cache()` continue
+to work and are thin wrappers over `cache.clear("all")`, `cache.disable_cache("all")`,
+and `cache.enable_cache("all")` respectively.
 
 ### Compatibility with Version 1.x
 

--- a/docs/docs/caching.md
+++ b/docs/docs/caching.md
@@ -1,385 +1,399 @@
 # Cache Management
 
-The package uses intelligent caching to speed up data access. Understanding how caching works helps you optimize performance and manage disk space.
+This page covers how `oda_data` manages its cache from version 2.6 onward. For
+quick recovery commands, skip to [Recovery from a corrupt cache](#recovery-from-a-corrupt-cache).
 
-## How Caching Works
+!!! info "Pre-2.6 users"
+    The 2.6 release reorganises the cache layout, splits responsibility between
+    `oda_data` and `oda_reader`, and replaces the legacy `set_data_path()` /
+    `clear_cache()` helpers with a typed `oda_data.cache.*` namespace. Existing
+    caches are migrated automatically on the first call after upgrade — see
+    [Migration from older versions](#migration-from-older-versions).
 
-The package implements a three-tier caching system:
+## Overview
 
-```
-┌─────────────────┐
-│  Memory Cache   │  ← Fastest: In-RAM storage
-├─────────────────┤
-│   Query Cache   │  ← Fast: Filtered datasets
-├─────────────────┤
-│   Bulk Cache    │  ← Large: Complete database files
-└─────────────────┘
-```
+Starting in `oda_data 2.6`, the cache layer is split along responsibility lines:
 
-**When you request data:**
+- **`oda_reader`** owns the *raw bytes* layer: zip archives downloaded from the
+  OECD live in `oda_reader`'s raw cache.
+- **`oda_data`** owns the *cleaned parquet* layer: filtered, column-renamed
+  DataFrames ready for analysis live in `oda_data`'s bulk and query caches.
 
-1. **Check memory cache**: Is it already loaded in RAM?
-2. **Check query cache**: Is this exact filtered query cached?
-3. **Check bulk cache**: Is the bulk file downloaded?
-4. **Fetch from API**: Last resort, download from OECD
+Both layers are reachable through a single, version-stable public API at
+`oda_data.cache.*`. You do not need to interact with `oda_reader`'s cache
+directly unless you are a standalone `oda_reader` user (see
+[Standalone oda_reader users](#standalone-oda_reader-users)).
 
-## Setting Up Caching
+## Cache locations per OS
 
-### Set the Data Path
+The default cache root is determined by
+[`platformdirs`](https://github.com/platformdirs/platformdirs) and is
+version-segmented so that installs of different `oda_data` versions use
+separate directories automatically.
 
-```python title="Configure Cache Location"
-from oda_data import set_data_path
+| OS      | Default cache root                                                 |
+|---------|--------------------------------------------------------------------|
+| macOS   | `~/Library/Caches/oda-data/<version>/`                             |
+| Linux   | `~/.cache/oda-data/<version>/`                                     |
+| Windows | `C:\Users\<user>\AppData\Local\oda-data\oda-data\Cache\<version>\` |
 
-# All cached data goes here
-set_data_path("data")
+Inside that root, four subdirectories hold the respective cache scopes:
 
-# Creates directory structure:
-# data/
-# ├── bulk/          # Bulk downloads
-# ├── queries/       # Filtered query results
-# └── .pydeflate/    # Currency conversion data
-```
+| Subdirectory   | Scope   | Contents                                          |
+|----------------|---------|---------------------------------------------------|
+| `bulk_cache/`  | `bulk`  | Cleaned parquet files extracted from OECD zips    |
+| `query_cache/` | `query` | Filter-specific parquet slices                    |
+| `http/`        | `http`  | HTTP-level response cache (managed by oda_reader) |
+| `raw/`         | `raw`   | Raw OECD zip archives (managed by oda_reader)     |
 
-### Default Cache Location
+## Configuring the cache root
 
-If you don't set a path, the package uses a default:
+### Environment variable
 
-```python
-# Default: .raw_data/ in your working directory
-# Automatically created when needed
-```
-
-## Cache Tiers Explained
-
-### 1. Memory Cache
-
-Fast, temporary storage while your Python session runs.
-
-```python title="Memory Cache in Action"
-from oda_data import OECDClient
-
-client = OECDClient(years=[2022])
-
-# First call: Downloads and caches in memory
-data1 = client.get_indicators("DAC1.10.1010")  # Slow
-
-# Second call: Retrieved from memory
-data2 = client.get_indicators("DAC1.10.1010")  # Fast!
-
-# Memory cache clears when Python session ends
-```
-
-**Characteristics:**
-
-- Very fast access
-- Limited by available RAM
-- Cleared when Python exits
-- Shared across queries in same session
-
-### 2. Query Cache
-
-Stores filtered datasets on disk for reuse.
-
-```python title="Query Cache Persistence"
-from oda_data import OECDClient, set_data_path
-
-set_data_path("data")
-
-client = OECDClient(
-    years=[2022],
-    providers=[4, 12],
-    currency="EUR"
-)
-
-# First run: Processes and caches result
-data = client.get_indicators("DAC1.10.1010")
-
-# Next day, same query: Instant!
-# Loads from query cache, no processing needed
-```
-
-**Characteristics:**
-
-- Persists across sessions
-- Specific to filter combinations
-- Smaller than bulk files
-- Automatically managed
-
-### 3. Bulk Cache
-
-Stores complete database downloads.
-
-```python title="Bulk Cache for Large Datasets"
-from oda_data import DAC1Data, set_data_path
-
-set_data_path("data")
-
-dac1 = DAC1Data(years=range(2010, 2024))
-
-# First time: Downloads entire bulk file (few minutes)
-dac1.download(bulk=True)
-
-# Subsequent queries: Reads from cached file (seconds)
-data = dac1.read(using_bulk_download=True)
-```
-
-**Characteristics:**
-
-- Complete database tables
-- Large file size (100s of MB)
-- Persists across sessions
-- Shared across all queries using that database
-
-## Managing Cache
-
-### Clear All Caches
-
-```python title="Clear All Cached Data"
-from oda_data import clear_cache
-
-# Removes all cached data
-clear_cache()
-
-# Everything will be re-downloaded on next use
-```
-
-!!! warning "Disk Space"
-    Clearing cache means the next queries will download data again. Only clear cache when you need to free disk space or force fresh downloads.
-
-### Disable Caching Temporarily
-
-```python title="Disable Cache for Development"
-from oda_data import disable_cache, enable_cache
-
-# Turn off caching
-disable_cache()
-
-# Now every query fetches fresh data
-client = OECDClient(years=[2022])
-data = client.get_indicators("DAC1.10.1010")  # Always downloads
-
-# Re-enable caching
-enable_cache()
-```
-
-**Use cases for disabling cache:**
-
-- Testing with latest OECD data
-- Debugging cache-related issues
-- Development and testing
-- Ensuring data freshness
-
-### Check Cache Location
-
-```python title="Find Your Cache Directory"
-from oda_data.config import ODAPaths
-
-print(f"Cache directory: {ODAPaths.raw_data}")
-```
-
-### Manual Cache Cleanup
-
-You can manually manage cache files:
+Set `ODA_DATA_CACHE_DIR` before starting Python (or before the first
+cache-touching call in a session) to override the default location:
 
 ```bash
-# View cache size
-du -sh data/
-
-# Remove old bulk files
-rm data/bulk/*
-
-# Remove query cache
-rm -rf data/queries/
+export ODA_DATA_CACHE_DIR=/data/shared/oda-cache
 ```
 
-## Performance Optimization
-
-### Pattern: Use Bulk Downloads for Multiple Queries
-
-```python title="Optimize with Bulk Downloads"
-from oda_data import OECDClient, set_data_path
-
-set_data_path("data")
-
-# Enable bulk download once
-client = OECDClient(
-    years=range(2015, 2024),
-    use_bulk_download=True
-)
-
-# First call downloads bulk file (slow initial download)
-data1 = client.get_indicators("DAC1.10.1010")
-
-# Subsequent calls are very fast
-data2 = client.get_indicators("DAC1.10.1015")
-data3 = client.get_indicators("DAC1.10.1210")
-# All fast because they use the same cached bulk file
-```
-
-## Cache Lifetime and Refresh
-
-### When Cache is Invalidated
-
-Cache is automatically refreshed when:
-
-- Bulk file is older than 30 days (stale data check)
-- You explicitly clear cache
-- OECD releases new data versions
-
-### Force Fresh Data
-
-```python title="Force Download of Latest Data"
-from oda_data import clear_cache, OECDClient
-
-# Clear cache to force fresh download
-clear_cache()
-
-# Next query gets latest data
-client = OECDClient(years=[2023])
-fresh_data = client.get_indicators("DAC1.10.1010")
-```
-
-### Check Data Freshness
-
-```python title="Verify When Data Was Cached"
-import os
-from pathlib import Path
-from datetime import datetime
-from oda_data.config import ODAPaths
-
-# Check bulk file modification time
-bulk_dir = ODAPaths.raw_data / "bulk"
-
-if bulk_dir.exists():
-    for file in bulk_dir.glob("*.parquet"):
-        mtime = os.path.getmtime(file)
-        mod_date = datetime.fromtimestamp(mtime)
-        print(f"{file.name}: Last modified {mod_date}")
-```
-
-## Troubleshooting
-
-### Issue: Cache taking too much space
-
-**Solution:** Clear old caches or remove specific bulk files:
+### Python API
 
 ```python
-from oda_data import clear_cache
+import oda_data
 
-# Nuclear option: clear everything
-clear_cache()
-
-# Or manually remove large bulk files you don't need
-# rm data/bulk/CRS_*.parquet
+oda_data.set_cache_root("/data/shared/oda-cache")
 ```
 
-### Issue: Getting old data
+`set_cache_root` takes priority over `ODA_DATA_CACHE_DIR`. Both are respected
+lazily on the first cache access, so they work even if called after
+`import oda_data`.
 
-**Solution:** Force refresh:
+### Note on `set_data_path`
+
+`set_data_path()` governs only *data outputs* (parquet exports) as of 2.6. It no
+longer controls the cache location. Calling it emits a one-time
+`DeprecationWarning` pointing at `set_cache_root` and `ODA_DATA_CACHE_DIR`. The
+shim is preserved through `oda_data 2.x` and removed in `3.0`.
+
+## The Python API
+
+All public cache operations live under `oda_data.cache`. Import the namespace
+once and call functions directly:
 
 ```python
-from oda_data import clear_cache, OECDClient
-
-clear_cache()
-
-# Now get fresh data
-client = OECDClient(years=[2023])
-data = client.get_indicators("DAC1.10.1010")
+from oda_data import cache
 ```
 
-### Issue: Cache corrupted or causing errors
+`Scope` is one of `"all"`, `"bulk"`, `"query"`, `"http"`, `"raw"`. Every
+function that accepts a `scope` argument raises `ValueError` for unknown values.
 
-**Solution:** Clear and rebuild:
+### `cache.path(scope="all") -> Path`
+
+Return the cache root directory, or the subdirectory for a specific scope.
 
 ```python
-from oda_data import clear_cache, set_data_path
-
-# Clear all caches
-clear_cache()
-
-# Re-set path to ensure clean state
-set_data_path("data")
-
-# Cache will rebuild correctly on next use
+cache.path()          # e.g. ~/Library/Caches/oda-data/2.6.0/
+cache.path("bulk")    # e.g. ~/Library/Caches/oda-data/2.6.0/oda-data/bulk_cache/
+cache.path("raw")     # e.g. ~/Library/Caches/oda-data/2.6.0/oda-reader/raw/
 ```
 
-### Issue: Working across multiple projects
+### `cache.entries() -> dict[Scope, list[CacheRecord]]`
 
-**Solution:** Use project-specific cache paths:
+Return all cached files grouped by scope. Each `CacheRecord` has `key`, `path`,
+`size_bytes`, `age_days`, `version`, and `scope` fields.
 
 ```python
-# Project 1
-from oda_data import set_data_path
-set_data_path("project1/data")
-
-# Project 2
-from oda_data import set_data_path
-set_data_path("project2/data")
-
-# Each project has its own cache
+for scope, records in cache.entries().items():
+    for r in records:
+        print(r.scope, r.key, r.size_bytes, r.age_days)
 ```
 
-## Advanced: Multi-Process Safety
+`"all"` is never a key in the returned dict — only the four concrete scopes
+(`"bulk"`, `"query"`, `"http"`, `"raw"`) appear.
 
-The package uses file locks to prevent cache corruption in multi-process scenarios:
+### `cache.clear(scope="all", *, blocking=True) -> dict[Scope, int | None]`
 
-```python title="Safe for Parallel Processing"
-from multiprocessing import Pool
-from oda_data import OECDClient, set_data_path
+Delete cached files in the named scope. Returns the count of files deleted per
+scope. For the `"bulk"` and `"query"` scopes (which `oda_data` writes under a
+`FileLock`), the value is `None` if the scope was skipped because another
+process held the write lock and `blocking=False` was passed. The `"http"` and
+`"raw"` scopes always return an `int` — see the
+[Multi-process behavior](#multi-process-behavior) section for why.
 
-def fetch_indicator(indicator):
-    set_data_path("data")  # Same cache for all processes
-    client = OECDClient(years=[2022])
-    return client.get_indicators(indicator)
+```python
+# Clear everything, waiting for any write lock (default):
+cache.clear()
 
-# Safe: Multiple processes can share cache
-if __name__ == "__main__":
-    indicators = ["DAC1.10.1010", "DAC1.10.1015", "DAC1.10.1210"]
-    with Pool(3) as pool:
-        results = pool.map(fetch_indicator, indicators)
+# Clear only the raw zip cache:
+cache.clear("raw")
+
+# Non-blocking: skip contended scopes instead of waiting:
+result = cache.clear("bulk", blocking=False)
+if result.get("bulk") is None:
+    print("bulk cache is busy — try again later")
 ```
 
-File locks prevent:
+The distinction between `0` (scope was reachable but empty) and `None` (scope
+was locked by another writer) is intentional; it applies only to the `"bulk"`
+and `"query"` scopes, which `oda_data` manages under a `FileLock`.
 
-- Race conditions during downloads
-- Corrupted cache files
-- Duplicate downloads
+### `cache.size() -> dict[Scope, int]`
 
-## Best Practices
+Return on-disk usage in bytes per scope (the four concrete scopes; not `"all"`).
 
-**Do:**
+```python
+sizes = cache.size()
+for scope, nbytes in sizes.items():
+    print(f"{scope}: {nbytes / 2**20:.1f} MB")
+```
 
-- Set a persistent data path for your project
-- Use bulk downloads for multiple queries
-- Reuse client configurations
-- Clear cache periodically to free space
-- Pre-download bulk files for offline work
+As a side effect, if the combined size of the current cache root **and** any
+sibling version directories (caches from older `oda_data` installs) exceeds
+5 GB, one `WARNING` is logged per process with a pointer to the older
+directories and the `cache.clear(scope="raw")` recovery hint.
 
-**Don't:**
+### `cache.invalidate(dataset: type[Source] | str) -> None`
 
-- Clear cache unnecessarily (wastes time re-downloading)
-- Use different data paths for the same project
-- Disable caching in production code
-- Manually edit cache files (can corrupt them)
-- Keep very old cache files (may be stale)
+Remove bulk and query cache entries for a single dataset. The argument can be
+either the class itself or its name as an exact-match string (case-sensitive).
+Raises `ValueError` for unrecognised names.
 
-## Summary
+!!! warning "Blocking semantics"
+    `cache.invalidate` acquires the bulk and query write locks (60-second
+    timeout each) so the unlink sequence cannot race with concurrent writers.
+    Do not call `cache.invalidate` from inside a `BulkCacheManager` or
+    `QueryCacheManager` write context — the caller would deadlock against
+    itself. On `filelock.Timeout`, retry after the current writer completes;
+    persistent timeouts may require a manual `cache.clear()`.
 
-The caching system makes the package fast and efficient:
+```python
+from oda_data import cache, CRSData
 
-- **Memory cache**: Instant access during your session
-- **Query cache**: Fast retrieval of previous filtered queries
-- **Bulk cache**: Quick access to complete databases
+# By class:
+cache.invalidate(CRSData)
 
-Manage caches with:
+# By name string (exact, case-sensitive):
+cache.invalidate("CRSData")
+```
 
-- `set_data_path()` - Configure where cache is stored
-- `clear_cache()` - Remove all cached data
-- `disable_cache()`/`enable_cache()` - Control caching behavior
+### `cache.enable_cache(scope="all")` / `cache.disable_cache(scope="all")`
 
-Understanding caching helps you:
+Toggle caching for a specific scope, or all scopes at once. Disabling a scope
+causes reads to bypass the cache layer for that scope until it is re-enabled.
+Useful in tests or when disk space is constrained.
 
-- Optimize query performance
-- Manage disk space
-- Ensure data freshness
-- Work efficiently offline
+```python
+cache.disable_cache("bulk")   # subsequent reads skip the bulk parquet cache
+# ... do work ...
+cache.enable_cache("bulk")    # restore normal behaviour
+```
+
+!!! note "Coupled http/raw toggle"
+    `"http"` and `"raw"` share a single underlying enable/disable toggle managed
+    by `oda_reader`. Enabling or disabling either scope toggles both: for
+    example, `cache.disable_cache("http")` will also disable `"raw"`, and vice
+    versa. `oda_data` mirrors this coupling in its own per-scope flags so
+    `is_scope_enabled` reports a consistent state on both sides. To toggle only
+    the `oda_data`-owned scopes without affecting `oda_reader`, use `"bulk"` or
+    `"query"` explicitly.
+
+### `cache.migrate(*, force=False) -> list[MigrationResult]`
+
+Manually re-run migration from pre-2.6 cache layouts (normally triggered
+automatically on the first cache-touching call). Pass `force=True` to override
+the synced-drive guard. Returns one `MigrationResult` per detected source root.
+
+```python
+results = cache.migrate(force=True)
+for r in results:
+    print(r.source, r.status, r.files_moved, r.bytes_moved)
+```
+
+### Scope reference
+
+| Scope   | Owner        | What it holds                                                              |
+|---------|--------------|----------------------------------------------------------------------------|
+| `all`   | —            | Shorthand for every scope at once. Not a key in `entries()` or `size()`.   |
+| `bulk`  | `oda_data`   | Cleaned parquet files extracted from OECD bulk zips.                       |
+| `query` | `oda_data`   | Filter-specific parquet slices derived from bulk files.                    |
+| `http`  | `oda_reader` | HTTP-level response cache.                                                 |
+| `raw`   | `oda_reader` | Raw OECD zip archives before extraction.                                   |
+
+When troubleshooting corrupt downloads, start with `cache.clear("raw")` — it
+removes the raw zip archives without touching the cleaned parquet files.
+Clearing `"bulk"` or `"query"` forces parquet re-extraction without
+re-downloading the underlying zip.
+
+### `read(refresh=True)` — per-call bypass
+
+Pass `refresh=True` to any dataset read call to bypass the bulk cache and
+re-download fresh data on that specific call. This is equivalent to calling
+`cache.invalidate(dataset)` before reading, but scoped to the single call and
+without permanently removing the cache entry.
+
+```python
+from oda_data import CRSData
+
+crs = CRSData(years=[2023])
+df = crs.read(using_bulk_download=True, refresh=True)
+```
+
+This works on all dataset classes: `CRSData`, `DAC1Data`, `DAC2AData`,
+`MultiSystemData`, and `AidDataData`.
+
+## Migration from older versions
+
+On the first cache-touching call after upgrading to `oda_data 2.6`, the package
+automatically detects pre-2.6 cache trees in the following locations and
+migrates them to the new layout:
+
+- `<cwd>/.raw_data/` (the old CWD-relative default)
+- `~/Library/Caches/oda-reader/<old-version>/` (macOS)
+- `~/.cache/oda-reader/<old-version>/` (Linux)
+- `%LOCALAPPDATA%\oda-reader\Cache\` (Windows)
+
+Migration rules:
+
+- **Same-volume**: files are moved via `shutil.move` (fast, no extra disk space
+  needed).
+- **Cross-volume**: files are copied with `shutil.copy2`, size-verified, then
+  the original is deleted. A progress message is logged because this can take
+  several minutes for large caches (~1 GB).
+- **Synced drive** (Dropbox, iCloud Drive, OneDrive): migration is skipped and
+  a clear message is logged. The old cache remains readable for that session.
+  Run `oda_data.cache.migrate(force=True)` in Python to override the guard.
+- **Disk full** (`errno 28`): migration is skipped and a `WARNING` is logged.
+  Both old and new locations are left intact.
+
+After a successful migration, a `.migrated_to` breadcrumb file is written at
+the old root containing the absolute new path. Running `oda_data 2.5.x`
+against a migrated tree will raise a `RuntimeError` directing you to upgrade.
+
+### Manual migration
+
+```python
+from oda_data import cache
+
+# Re-run migration with the synced-drive guard disabled:
+results = cache.migrate(force=True)
+for r in results:
+    print(r.source, r.status, r.files_moved, r.bytes_moved)
+```
+
+`cache.migrate()` returns a `list[MigrationResult]`, one per detected source
+root. Each `MigrationResult` has `source`, `status`, `files_moved`,
+`bytes_moved`, and `message` fields.
+
+## Recovery from a corrupt cache
+
+If `oda_data` raises `BulkPayloadCorrupt` or you see stale/corrupt data, clear
+the raw cache and retry:
+
+```python
+from oda_data import cache, CRSData
+
+# Wipe the raw zip cache managed by oda_reader:
+cache.clear("raw")
+# Or wipe everything: cache.clear("all")
+
+# Re-read normally — the zip will be re-downloaded:
+df = CRSData(years=[2023]).read(using_bulk_download=True)
+```
+
+`BulkPayloadCorrupt` is raised when a freshly downloaded zip fails
+`is_zipfile()` or `ZipFile.testzip()` integrity checks. The exception carries
+`.path` (the corrupt file's location) and `.reason` (which check failed).
+`oda_data` automatically clears the bad entry and retries the download once;
+the exception only surfaces to the caller if both the original download and
+the retry fail.
+
+If you want to skip the raw cache entirely for a single call (useful when the
+network feed may be temporarily corrupt but you do not want to wipe the whole
+cache), pass `use_raw_cache=False` to the underlying `oda_reader` bulk
+functions directly, or call `read` with `refresh=True` to bypass at the
+`oda_data` level:
+
+```python
+# Skip the raw zip cache for this call only; no disk footprint, re-downloads every time:
+from oda_reader import bulk_download_crs
+bulk_download_crs(save_to_path="/tmp/crs", use_raw_cache=False)
+```
+
+## Multi-process behavior
+
+`oda_data` uses `filelock.FileLock` to coordinate cache writes across
+processes. Concurrent reads are always safe because readers never hold a write
+lock.
+
+Write coordination:
+
+- **`BulkCacheManager`** acquires the lock before writing a new zip download.
+  If two notebooks start `crs.read(using_bulk_download=True)` at the same
+  time, the second blocks until the first completes and then reads from the
+  already-written cache entry — only one network download occurs.
+- **`cache.clear(blocking=True)`** (the default): acquires the lock and waits
+  up to 1200 s for any in-progress write to finish.
+- **`cache.clear(blocking=False)`**: skips scopes under contention instead of
+  blocking. Returns `None` for each contended `"bulk"` / `"query"` scope
+  (rather than `0`, which means the scope was reachable but empty). The
+  `"http"` and `"raw"` scopes always return an `int` — `oda_reader` does not
+  expose a public lock path for those caches, so contention cannot be
+  detected; every reachable file is unlinked unconditionally. This distinction
+  matters when the caller needs to confirm whether a clear was actually
+  attempted.
+
+!!! note "Crash recovery"
+    If a process is SIGKILLed mid-write, the incomplete file is left at a
+    `.tmp-<host>-<pid>` path. On the next `CacheManager` initialisation
+    (which happens at the start of every read session), any `*.tmp-*` file
+    with an mtime older than 24 hours is automatically removed. The `<host>`
+    component in the suffix prevents PID collisions on NFS or other shared
+    mounts across multiple machines.
+
+## Standalone `oda_reader` users
+
+Users who import `oda_reader` directly without `oda_data` can continue to use
+the four legacy helpers unchanged:
+
+```python
+import oda_reader
+
+oda_reader.set_cache_dir("/my/cache")
+oda_reader.clear_cache()
+oda_reader.enable_cache()
+oda_reader.disable_cache()
+```
+
+These functions are fully functional and will not be removed until
+`oda_reader 2.0`.
+
+**If `oda_data` is also imported in the same process**, each of these functions
+emits a one-time `DeprecationWarning` (once per function per session)
+directing you to the equivalent `oda_data.cache.*` call:
+
+| Legacy call                         | `oda_data` equivalent                    |
+|-------------------------------------|------------------------------------------|
+| `oda_reader.set_cache_dir(path)`    | `oda_data.set_cache_root(path)`          |
+| `oda_reader.clear_cache()`          | `oda_data.cache.clear("all")`            |
+| `oda_reader.enable_cache()`         | `oda_data.cache.enable_cache("all")`     |
+| `oda_reader.disable_cache()`        | `oda_data.cache.disable_cache("all")`    |
+
+Standalone `oda_reader` users who do **not** also import `oda_data` will never
+see these warnings. The shims are preserved through `oda_reader 1.x` and
+removed in `2.0`.
+
+## Top-level back-compat helpers
+
+For `oda_data` users who relied on the v1.x / early-v2.x top-level helpers, the
+following names continue to work and are now thin wrappers over the
+`cache.*` API:
+
+| Top-level call          | New equivalent                       |
+|-------------------------|--------------------------------------|
+| `clear_cache()`         | `cache.clear("all")`                 |
+| `enable_cache()`        | `cache.enable_cache("all")`          |
+| `disable_cache()`       | `cache.disable_cache("all")`         |
+
+Prefer the `cache.*` namespace in new code — it is scope-aware and returns
+structured results.

--- a/docs/docs/changelog.md
+++ b/docs/docs/changelog.md
@@ -5,6 +5,131 @@ All notable changes to the oda_data package are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.6.0] - 2026-04-28
+
+This release reorganises how `oda_data` stores downloaded data on disk.
+Caches now live in a standard per-user location instead of inside your
+project folder, and a new `oda_data.cache.*` namespace gives you a clear,
+typed way to inspect and manage them. Existing caches are migrated
+automatically on first run. See [Cache Management](caching.md) for the
+full walkthrough.
+
+### Added
+- **Per-user cache by default.** Downloads now live under your OS's standard
+  cache directory (`~/Library/Caches/oda-data/` on macOS,
+  `~/.cache/oda-data/` on Linux, `%LOCALAPPDATA%\oda-data\` on Windows),
+  versioned per release. This means cache is shared across projects instead
+  of duplicated in every `.raw_data/` folder, and old versions don't silently
+  get re-used after an upgrade.
+- **Override the cache location** with `oda_data.set_cache_root(path)` or
+  the `ODA_DATA_CACHE_DIR` environment variable — useful for shared volumes
+  or CI runners with limited home-directory space.
+- **One place to manage the cache: `oda_data.cache`.** Inspect what's
+  cached, clear specific parts, or invalidate a single dataset without
+  touching the rest:
+
+    ```python
+    from oda_data import cache, CRSData
+
+    cache.size()                # bytes per scope
+    cache.clear("raw")          # drop only raw OECD zips
+    cache.invalidate(CRSData)   # forget cached CRS, keep everything else
+    ```
+
+- **Per-call `refresh=True`** on every dataset's `read()` to force a fresh
+  download for one call without permanently clearing the cache.
+- **Automatic recovery from corrupt downloads.** When a freshly downloaded
+  zip fails its integrity check, the bad file is removed and the download
+  is retried once. If both attempts fail, you get a clear
+  `BulkPayloadCorrupt` error pointing at the file and the reason.
+
+### Changed
+- **`set_data_path()` no longer controls the cache.** It now only sets
+  where the package writes parquet *exports* (data you explicitly save
+  out). If you used it to redirect cache storage, switch to
+  `set_cache_root()` or `ODA_DATA_CACHE_DIR` — the package will print a
+  one-time deprecation warning to remind you. The old call still works
+  through 2.x and is removed in 3.0.
+- **`clear_cache()`, `enable_cache()`, and `disable_cache()` still work**
+  unchanged. They now delegate to the new `cache.*` namespace, so existing
+  scripts keep running without edits.
+
+### Migration
+On the first cache-touching call after upgrading, the package looks for
+pre-2.6 caches in their old locations (`./.raw_data/`, the per-OS
+`oda-reader` directory) and moves them into the new layout. Caches on
+synced drives (Dropbox, iCloud, OneDrive) are skipped with a clear log
+message — re-run with `oda_data.cache.migrate(force=True)` to override.
+
+## [2.5.1] - 2026-04-28
+
+### Fixed
+- OECD CRS bulk downloads using the newer PKZIP Deflate64 compression
+  method no longer fail with `BadZipFile: File is not a zip file`. Pulled
+  in via `oda-reader >= 1.5.1`. If you saw this error before upgrading,
+  delete any stale file under your `oda-reader` bulk cache (path varies by
+  OS) before retrying.
+
+## [2.5.0] - 2026-04-09
+
+### Changed
+- Romania (code 77) is now classified as a DAC member/country (previously non-DAC),
+  reflecting its new status as a DAC associate.
+
+## [2.4.2] - 2026-02-13
+
+### Fixed
+- Memory cache returning stale results when a cached DataFrame lacks columns requested
+  by a subsequent query.
+
+## [2.4.1] - 2025-12-19
+
+### Added
+- CRS column mappings for `donor` → `provider_name` and `recipient` → `recipient_name`.
+
+## [2.4.0] - 2025-12-19
+
+### Added
+- New `DATA_TYPE_CODE` field to ODASchema and CRS column mapping for datatype_code
+  column support.
+
+### Changed
+- DAC2A bulk downloads now use dedicated `bulk_download_dac2a()` function from
+  oda-reader for improved reliability.
+- Measure filters are now skipped for DAC2A when using bulk downloads (consistent
+  with CRS behavior).
+- Updated oda-reader dependency from `>=1.3.1` to `>=1.4.1`.
+
+## [2.3.2] - 2025-12-19
+
+### Added
+- New Development Bank (code 1044) to provider groupings, CRS names, and DAC2A names.
+- Eurasian Fund for Stabilization and Development (code 1041) to provider groupings,
+  CRS names, and DAC2A names.
+- UN Economic and Social Commission for Western Asia (code 1403) to provider
+  groupings and DAC2A names.
+
+## [2.3.1] - 2025-12-15
+
+### Added
+- European Investment Bank (EIB, code 919) to provider/donor mappings across DAC1,
+  DAC2A, CRS, and provider groupings.
+- New unspecified regional recipient codes: Southern Asia (6790), Micronesia (8600),
+  Middle Africa (10280), Melanesia (10330), Polynesia (10350).
+- Broad sector categories for top-level aggregation: Education, Health, Energy,
+  General Environment Protection, Agriculture and Forestry & Fishing.
+- New sector/purpose mappings including Conflict/Peace/Security (152),
+  Trade Policies (331), Refugees (930), Humanitarian Aid (700).
+
+### Fixed
+- Type conversion for code columns (`sector_code`, `purpose_code`, `donor_code`,
+  `agency_code`) when adding name columns to handle mixed types.
+- Typo in sector name: "Unallocated/ Unspecificed" → "Unallocated/ Unspecified".
+- Capitalization in broad sector groups: "government & Civil Society" →
+  "Government & Civil Society".
+- Sector mapping now uses fallback for unmapped sectors and fills missing values
+  with "Unallocated/ Unspecified".
+
 ## [2.3.0] - 2025-10-16
 
 ### Added

--- a/docs/docs/currencies-prices.md
+++ b/docs/docs/currencies-prices.md
@@ -70,9 +70,7 @@ Available currencies: ['USD', 'EUR', 'GBP', 'CAD', 'LCU']
 ### Get Data in Euros
 
 ```python title="Convert USD Data to EUR"
-from oda_data import OECDClient, set_data_path
-
-set_data_path("data")
+from oda_data import OECDClient
 
 # Default is USD, current prices
 client_usd = OECDClient(years=[2022])

--- a/docs/docs/data-sources.md
+++ b/docs/docs/data-sources.md
@@ -39,9 +39,7 @@ DAC1 contains aggregate statistics for each donor—total ODA, multilateral ODA,
 ### Basic Usage
 
 ```python title="Download and Read Complete DAC1 Data"
-from oda_data import DAC1Data, set_data_path
-
-set_data_path("data")
+from oda_data import DAC1Data
 
 # Instantiate DAC1 data source
 dac1 = DAC1Data()
@@ -56,9 +54,7 @@ print(data.head())
 ### Filtered Download
 
 ```python title="Download Specific Years and Donors"
-from oda_data import DAC1Data, set_data_path
-
-set_data_path("data")
+from oda_data import DAC1Data
 
 # Download only what you need
 dac1 = DAC1Data(
@@ -76,9 +72,7 @@ print(data.head())
 ### Custom Read Filters
 
 ```python title="Filter Data When Reading"
-from oda_data import DAC1Data, set_data_path
-
-set_data_path("data")
+from oda_data import DAC1Data
 
 dac1 = DAC1Data(years=2022)
 
@@ -102,9 +96,7 @@ DAC2A shows bilateral aid from each donor to each recipient country.
 ### Basic Usage
 
 ```python title="Download Complete DAC2A Data"
-from oda_data import DAC2AData, set_data_path
-
-set_data_path("data")
+from oda_data import DAC2AData
 
 dac2a = DAC2AData()
 
@@ -117,9 +109,7 @@ print(f"Shape: {data.shape}")
 ### Filtered by Donor and Recipient
 
 ```python title="Download France's Aid to African Countries"
-from oda_data import DAC2AData, recipient_groupings, set_data_path
-
-set_data_path("data")
+from oda_data import DAC2AData, recipient_groupings
 
 # Get African countries
 africa = list(recipient_groupings()["african_countries"])
@@ -139,9 +129,7 @@ print(data.head())
 ### Advanced Filtering
 
 ```python title="Filter by Flow Type and Prices"
-from oda_data import DAC2AData, set_data_path
-
-set_data_path("data")
+from oda_data import DAC2AData
 
 dac2a = DAC2AData(years=[2022], providers=[4])
 data = dac2a.read(
@@ -166,9 +154,7 @@ The Creditor Reporting System (CRS) contains detailed, project-level ODA data in
 ### Basic Usage
 
 ```python title="Download CRS Data (Always Use Bulk)"
-from oda_data import CRSData, set_data_path
-
-set_data_path("data")
+from oda_data import CRSData
 
 # CRS should ALWAYS use bulk download
 crs = CRSData(years=range(2020, 2023))
@@ -183,9 +169,7 @@ print(data.columns.tolist())
 ### Filtered CRS Query
 
 ```python title="Get Education Projects in East Africa"
-from oda_data import CRSData, set_data_path
-
-set_data_path("data")
+from oda_data import CRSData
 
 crs = CRSData(
     years=[2022],
@@ -208,9 +192,7 @@ print(data[["donor_name", "recipient_name", "sector_name", "project_title", "usd
 ### Analyze Project Characteristics
 
 ```python title="Analyze CRS Project Data"
-from oda_data import CRSData, set_data_path
-
-set_data_path("data")
+from oda_data import CRSData
 
 crs = CRSData(years=[2022])
 data = crs.read(using_bulk_download=True)
@@ -239,9 +221,7 @@ MultiSystemData tracks how donors provide aid to or through the multilateral sys
 ### Basic Usage
 
 ```python title="Download MultiSystem Data"
-from oda_data import MultiSystemData, set_data_path
-
-set_data_path("data")
+from oda_data import MultiSystemData
 
 multisystem = MultiSystemData(years=range(2020, 2023))
 
@@ -254,9 +234,7 @@ print(data.head())
 ### Filter by Aid Type
 
 ```python title="Analyze Aid Through Multilateral Organizations"
-from oda_data import MultiSystemData, set_data_path
-
-set_data_path("data")
+from oda_data import MultiSystemData
 
 multisystem = MultiSystemData(
     years=[2022],

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -12,19 +12,25 @@ pip install oda-data --upgrade
 
 ## Your First ODA Data
 
-### Set Up Data Storage
+### Where the data lives
 
-Before fetching data, tell the package where to cache downloaded files:
+You don't need to configure anything to get started. From version 2.6 onward,
+`oda_data` caches downloads in a standard per-user directory
+(`~/Library/Caches/oda-data/` on macOS, `~/.cache/oda-data/` on Linux, the
+equivalent `AppData\Local` path on Windows), so subsequent queries are fast.
+
+If you want to override that location — for example to use a shared volume or
+to keep cache outside your home directory — use `set_cache_root()` or the
+`ODA_DATA_CACHE_DIR` environment variable:
 
 ```python
-from oda_data import set_data_path
+from oda_data import set_cache_root
 
-# This creates a folder to store cached data
-set_data_path("data")
+set_cache_root("/path/to/cache")
 ```
 
-!!! tip "Choose Your Data Path"
-    Pick a location where you want to cache ODA data. The package will create this folder if it doesn't exist. Cached data speeds up subsequent queries significantly.
+See [Cache Management](caching.md) for inspecting, clearing, and managing the
+cache.
 
 ### Example 1: Get Total ODA
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -11,10 +11,8 @@ This package simplifies that entire process. Whether you need total ODA flows, b
 **Easily get ODA data**
 
 ```python
-from oda_data import OECDClient, set_data_path
+from oda_data import OECDClient
 
-# Set a folder where to store the raw data
-set_data_path("data")
 client = OECDClient(years=range(2018, 2023), providers=[4, 302])  # France and USA
 data = client.get_indicators("DAC1.10.1010")  # Total ODA
 ```

--- a/docs/docs/migration.md
+++ b/docs/docs/migration.md
@@ -193,9 +193,7 @@ data = read_dac1(
 
 **v2.x:**
 ```python
-from oda_data import DAC1Data, set_data_path
-
-set_data_path("data")
+from oda_data import DAC1Data
 
 dac1 = DAC1Data(
     years=range(2020, 2023),
@@ -219,9 +217,7 @@ data = read_crs(
 
 **v2.x:**
 ```python
-from oda_data import CRSData, set_data_path
-
-set_data_path("data")
+from oda_data import CRSData
 
 crs = CRSData(
     years=[2022],
@@ -277,32 +273,43 @@ data = add_gni_share_column(client, "DAC1.10.1010")
 ```python
 from oda_data import set_data_path
 
+# Used to control where downloads were cached
 set_data_path("path/to/data")
 ```
 
-**v2.x:**
+**v2.x (2.6 and later):**
 ```python
-# Same!
-from oda_data import set_data_path
+# Cache is now per-user by default — no setup required for most users.
+# To override the cache location:
+from oda_data import set_cache_root
 
-set_data_path("path/to/data")
+set_cache_root("path/to/cache")
+
+# Or set the environment variable before starting Python:
+#   export ODA_DATA_CACHE_DIR=/path/to/cache
 ```
+
+`set_data_path()` still exists but, as of 2.6, only governs where the package
+writes parquet *exports* (data you explicitly save out) — not where downloads
+are cached. Calling it for cache purposes prints a one-time deprecation
+warning. See [Cache Management](caching.md) for the full picture.
 
 ### Cache Clearing
 
-**v1.x:**
+**v1.x and v2.x (back-compat):**
 ```python
 from oda_data import clear_cache
 
-clear_cache()
+clear_cache()  # still works, clears everything
 ```
 
-**v2.x:**
+**v2.x preferred (2.6 and later):**
 ```python
-# Same!
-from oda_data import clear_cache
+from oda_data import cache
 
-clear_cache()
+cache.clear()           # clear everything (same as clear_cache())
+cache.clear("raw")      # clear only the raw OECD zips
+cache.invalidate("CRSData")  # forget a single dataset
 ```
 
 ## Complete Migration Example
@@ -340,9 +347,7 @@ print(data.head())
 ### v2.x Equivalent
 
 ```python title="New v2.x Script"
-from oda_data import OECDClient, set_data_path, add_names_columns, add_gni_share_column
-
-set_data_path("data")
+from oda_data import OECDClient, add_names_columns, add_gni_share_column
 
 # Create client
 client = OECDClient(

--- a/docs/docs/oecd-client.md
+++ b/docs/docs/oecd-client.md
@@ -56,9 +56,7 @@ This creates a CSV file with all indicators, their descriptions, and sources. Op
 The simplest use case: get an indicator for specific years.
 
 ```python title="Get Total ODA for Recent Years"
-from oda_data import OECDClient, set_data_path
-
-set_data_path("data")
+from oda_data import OECDClient
 
 client = OECDClient(years=range(2018, 2023))
 data = client.get_indicators("DAC1.10.1010")
@@ -262,9 +260,7 @@ data = client.get_indicators(indicators)
 Here's a fully configured client showing all common options:
 
 ```python title="Fully Configured OECDClient"
-from oda_data import OECDClient, set_data_path
-
-set_data_path("data")
+from oda_data import OECDClient
 
 client = OECDClient(
     # Time period

--- a/docs/docs/policy-markers.md
+++ b/docs/docs/policy-markers.md
@@ -27,9 +27,7 @@ Each project receives a score indicating the priority of that objective:
 ### Get Gender-Focused ODA
 
 ```python title="Analyze Gender Equality ODA"
-from oda_data import bilateral_policy_marker, set_data_path
-
-set_data_path("data")
+from oda_data import bilateral_policy_marker
 
 # Get bilateral ODA with gender as principal objective
 gender_data = bilateral_policy_marker(

--- a/docs/docs/sector-imputations.md
+++ b/docs/docs/sector-imputations.md
@@ -67,10 +67,7 @@ The package uses **gross disbursements** throughout (not commitments), following
 This is the primary function for calculating imputed multilateral aid by sector:
 
 ```python title="Calculate Imputed Multilateral Aid by Sector"
-from oda_data import set_data_path
 from oda_data.indicators.research import sector_imputations
-
-set_data_path("data")
 
 # Get imputed multilateral aid for France
 # Note: Need 3 years for rolling average calculation
@@ -119,12 +116,10 @@ imputed_multilateral_by_purpose(
 Combine bilateral and imputed multilateral aid for total sectoral spending:
 
 ```python title="Total Sectoral ODA: Bilateral + Imputed Multilateral"
-from oda_data import CRSData, set_data_path
+from oda_data import CRSData
 from oda_data.indicators.research import sector_imputations
 from oda_data.tools.names.add import add_names_columns
 import pandas as pd
-
-set_data_path("data")
 
 # Step 1: Get bilateral aid by sector (from CRS)
 bilateral = sector_imputations.spending_by_purpose(
@@ -197,10 +192,7 @@ This shows France's top 5 ODA categories in 2021 (in millions USD, constant 2021
 For researchers needing more control, use the lower-level functions:
 
 ```python title="Custom Imputation Analysis"
-from oda_data import set_data_path
 from oda_data.indicators.research import sector_imputations
-
-set_data_path("data")
 
 # Get multilateral spending shares (3-year smoothed)
 spending_shares = sector_imputations.multilateral_spending_shares_by_channel_and_purpose_smoothed(
@@ -311,11 +303,8 @@ education = imputed[imputed["purpose_name"] == "Education"]  # May fail
 **Solution**: Use the `add_names_columns()` function to add human-readable names:
 
 ```python title="Add Names to Imputations"
-from oda_data import set_data_path
 from oda_data.indicators.research import sector_imputations
 from oda_data.tools.names.add import add_names_columns
-
-set_data_path("data")
 
 # Get imputed data
 imputed = sector_imputations.imputed_multilateral_by_purpose(years=[2021], providers=[4])
@@ -421,11 +410,9 @@ Different organizations use different imputation approaches. This package implem
 Reveal donors' **total** sectoral commitments across all channels:
 
 ```python title="Compare Bilateral vs Total Sectoral Support"
-from oda_data import CRSData, set_data_path
+from oda_data import CRSData
 from oda_data.indicators.research import sector_imputations
 from oda_data.tools.names.add import add_names_columns
-
-set_data_path("data")
 
 bilateral = sector_imputations.spending_by_purpose(
     years=[2021],

--- a/docs/docs/why-oda-data.md
+++ b/docs/docs/why-oda-data.md
@@ -30,9 +30,8 @@ Each has its own web interface, API endpoint, and data format. Getting a complet
 **With this package:**
 
 ```python
-from oda_data import OECDClient, set_data_path
+from oda_data import OECDClient
 
-set_data_path("data")
 client = OECDClient(years=range(2020, 2023))
 data = client.get_indicators("DAC1.10.1010")  # Done in 3 lines
 ```
@@ -199,9 +198,8 @@ from oda_data import sector_imputations
 **With ODA Data Package:**
 
 ```python
-from oda_data import OECDClient, set_data_path
+from oda_data import OECDClient
 
-set_data_path("data")
 client = OECDClient(years=range(2020, 2023), providers=[4])
 data = client.get_indicators("DAC1.10.1010")
 # Result: 10 seconds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "oda_data"
-version = "2.5.0"
+version = "2.6.0"
 description = "A python package to work with Official Development Assistance data from the OECD DAC."
 requires-python = ">=3.11"
 
@@ -28,7 +28,8 @@ classifiers = [
 dependencies = [
     "cachetools>=6.2.0",
     "filelock>=3.20.0",
-    "oda-reader>=1.4.1",
+    "oda-reader>=1.6.0",
+    "platformdirs>=4.0.0",
     "pandas[excel,parquet,performance]>=2.2.0",
     "pydeflate>=2.3.3",
     "reader>=3.18",
@@ -109,11 +110,16 @@ unfixable = []
 
 [tool.ruff.lint.per-file-ignores]
 # Allow test files to have longer lines and more assertions
-"tests/**/*.py" = ["E501", "PLR2004", "RUF002", "RUF003"]  # Allow × in comments/docstrings
+"tests/**/*.py" = ["E501", "PLR2004", "RUF002", "RUF003", "PLW0603"]  # Allow × in comments/docstrings; PLW0603 for spawn-pool worker globals
 # Allow global variable usage in __init__.py (architectural decision)
 "src/oda_data/__init__.py" = ["PLW0603", "PLW0602", "F811"]
+# Lazy module-level state (override flag, chained-root cache, auto-migrate gate, 5GB warning latch).
+"src/oda_data/cache/config.py" = ["PLW0603"]
+"src/oda_data/cache/api.py" = ["PLW0603"]
 # Allow tmpdir reassignment pattern (Path conversion)
 "src/oda_data/tools/cache.py" = ["PLW2901"]
+# Existing complexity in OECDClient._apply_filters — out of scope for refactor here.
+"src/oda_data/api/oecd.py" = ["PLR0912"]
 # Allow loop variable binding patterns (intentional for lambda closures)
 "src/oda_data/indicators/crs/crs_functions.py" = ["B023"]
 "src/oda_data/indicators/research/sector_imputations.py" = ["B023"]
@@ -132,3 +138,6 @@ skip-magic-trailing-comma = false
 
 # Like Black, automatically detect line endings
 line-ending = "auto"
+
+# Note: pytest configuration lives in `pytest.ini` (which takes precedence over
+# this file). Markers and addopts must be added there, not here.

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,11 +14,13 @@ addopts =
     --cov-report=term-missing
     --cov-report=html
     --cov-branch
+    -m "not integration and not network"
 
 # Custom markers for organizing tests
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
-    integration: marks tests as integration tests
+    integration: marks tests that call real OECD API (deselected by default)
+    network: marks tests requiring live network access (opt-in via RUN_NETWORK_TESTS=1; deselected by default)
     unit: marks tests as unit tests
     cache: marks tests related to caching functionality
     validation: marks tests related to input validation

--- a/src/oda_data/__init__.py
+++ b/src/oda_data/__init__.py
@@ -1,5 +1,6 @@
-from oda_reader import clear_cache, disable_cache, enable_cache, set_cache_dir
+import warnings
 
+from oda_data import cache
 from oda_data.api.oecd import OECDClient
 from oda_data.api.sources import (
     AidDataData,
@@ -8,6 +9,7 @@ from oda_data.api.sources import (
     DAC2AData,
     MultiSystemData,
 )
+from oda_data.cache.config import set_cache_root
 from oda_data.indicators.research import sector_imputations
 from oda_data.indicators.research.policy_markers import bilateral_policy_marker
 from oda_data.tools.compatibility import ODAData
@@ -16,23 +18,74 @@ from oda_data.tools.groupings import provider_groupings, recipient_groupings
 from oda_data.tools.names.add import add_names_columns
 from oda_data.tools.sector_lists import add_broad_sectors, add_sectors
 
+_DEPRECATION_WARNED_SET_DATA_PATH = False
 
-def set_data_path(path):
+
+def clear_cache() -> None:
+    """Back-compat alias for oda_data.cache.clear('all').
+
+    Clears all scopes (bulk, query, http, raw). Prefer ``oda_data.cache.clear()``.
+    """
+    from oda_data.cache import clear
+
+    clear("all")
+
+
+def disable_cache() -> None:
+    """Back-compat alias for oda_data.cache.disable_cache('all').
+
+    Disables all cache scopes. Prefer ``oda_data.cache.disable_cache()``.
+    """
+    from oda_data.cache import disable_cache as _disable
+
+    _disable("all")
+
+
+def enable_cache() -> None:
+    """Back-compat alias for oda_data.cache.enable_cache('all').
+
+    Enables all cache scopes. Prefer ``oda_data.cache.enable_cache()``.
+    """
+    from oda_data.cache import enable_cache as _enable
+
+    _enable("all")
+
+
+def set_data_path(path) -> None:
+    """Set the path for data outputs (parquet exports).
+
+    Deprecated: cache location is now controlled via set_cache_root() or
+    the ODA_DATA_CACHE_DIR env var. A one-time DeprecationWarning is emitted
+    on first call. Shim preserved through 2.x, removed in 3.0.
+    """
+    global _DEPRECATION_WARNED_SET_DATA_PATH
+
     from pathlib import Path
 
     from pydeflate import set_pydeflate_path
 
     from oda_data.config import ODAPaths
 
-    """Set the path to the data folder."""
-    global ODAPaths
+    if not _DEPRECATION_WARNED_SET_DATA_PATH:
+        warnings.warn(
+            "oda_data.set_data_path() now governs only data outputs (parquet exports),"
+            " not the cache. If you previously called set_data_path() to control where"
+            " downloads are cached, also call"
+            " oda_data.set_cache_root('<your_path>') or set the ODA_DATA_CACHE_DIR env"
+            " var. The set_data_path() shim itself is preserved through oda_data 2.x"
+            " and removed in 3.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        _DEPRECATION_WARNED_SET_DATA_PATH = True
 
     ODAPaths.raw_data = Path(path).resolve()
-    # Create on explicit user request; avoids import-time side effects
+    # Create on explicit user request; avoids import-time side effects.
     ODAPaths.raw_data.mkdir(parents=True, exist_ok=True)
     ODAPaths.pydeflate = ODAPaths.raw_data / ".pydeflate"
     set_pydeflate_path(ODAPaths.raw_data)
-    set_cache_dir(ODAPaths.raw_data)
+    # Do NOT call set_cache_dir here — cache chaining is handled lazily by
+    # oda_data_cache_root() inside cache/config.py.
 
 
 __all__ = [
@@ -48,12 +101,13 @@ __all__ = [
     "add_names_columns",
     "add_sectors",
     "bilateral_policy_marker",
+    "cache",
     "clear_cache",
     "disable_cache",
     "enable_cache",
     "provider_groupings",
     "recipient_groupings",
     "sector_imputations",
-    "set_cache_dir",
+    "set_cache_root",
     "set_data_path",
 ]

--- a/src/oda_data/api/sources.py
+++ b/src/oda_data/api/sources.py
@@ -123,41 +123,37 @@ class Source:
 
     @property
     def bulk_cache(self) -> BulkCacheManager:
-        """Get bulk cache manager singleton.
-
-        Creates one bulk cache per process, recreating if data directory changes.
-        """
-        current_raw = Path(ODAPaths.raw_data).resolve()
-        # Fast-path without lock
-        bc = Source._shared_bulk_cache
-        if bc is not None and bc.base_dir.parent.resolve() == current_raw:
-            return bc
-
-        # Slow-path with lock
-        with Source._cache_lock:
-            bc = Source._shared_bulk_cache
-            if bc is None or bc.base_dir.parent.resolve() != current_raw:
-                Source._shared_bulk_cache = BulkCacheManager(current_raw)
-            return Source._shared_bulk_cache
+        """Get bulk cache manager singleton, recreating if the cache root changed."""
+        return self._shared_manager(BulkCacheManager, "_shared_bulk_cache")
 
     @property
     def query_cache(self) -> QueryCacheManager:
-        """Get query cache manager singleton.
+        """Get query cache manager singleton, recreating if the cache root changed."""
+        return self._shared_manager(QueryCacheManager, "_shared_query_cache")
 
-        Creates one query cache per process, recreating if data directory changes.
+    @classmethod
+    def _shared_manager(cls, manager_cls, slot: str):
+        """Return a process-wide manager rooted at ``cache_root / "oda-data"``.
+
+        The singleton is intentionally anchored on ``Source`` (not on the
+        runtime subclass) so that every subclass shares the same instance.
+
+        The unresolved equality check on the fast path avoids a ``realpath``
+        syscall on every property access; we only ``.resolve()`` when the
+        configured root visibly changed.
         """
-        current_raw = Path(ODAPaths.raw_data).resolve()
-        # Fast-path without lock
-        qc = Source._shared_query_cache
-        if qc is not None and qc.base_dir.parent.resolve() == current_raw:
-            return qc
-
-        # Slow-path with lock
-        with Source._cache_lock:
-            qc = Source._shared_query_cache
-            if qc is None or qc.base_dir.parent.resolve() != current_raw:
-                Source._shared_query_cache = QueryCacheManager(current_raw)
-            return Source._shared_query_cache
+        current = Path(ODAPaths.cache_root) / "oda-data"
+        existing = getattr(Source, slot)
+        if existing is not None and existing.base_dir.parent == current:
+            return existing
+        with cls._cache_lock:
+            existing = getattr(Source, slot)
+            if (
+                existing is None
+                or existing.base_dir.parent.resolve() != current.resolve()
+            ):
+                setattr(Source, slot, manager_cls(current))
+            return getattr(Source, slot)
 
     def _add_filter(self, column: str, predicate: str, value: str | int | list) -> None:
         """Adds a filter to the dataset, ensuring no duplicate columns.
@@ -348,14 +344,23 @@ class DACSource(Source):
             return "unknown"
 
     def _fetch_from_bulk_cache(
-        self, filters: list[tuple] | None, columns: list | None
+        self,
+        filters: list[tuple] | None,
+        columns: list | None,
+        *,
+        refresh: bool = False,
     ) -> pd.DataFrame:
         """Fetch data from bulk cache with download coordination.
 
-        This method uses FileLock via BulkCacheManager - if another thread is
+        This method uses FileLock via BulkCacheManager — if another thread is
         downloading, this call blocks until download completes.
 
         Uses PyArrow predicate pushdown and column projection for maximum efficiency.
+
+        Args:
+            filters: Optional parquet predicate filters.
+            columns: Optional column subset.
+            refresh: If True, bypass the bulk cache and re-download.
         """
         entry = BulkCacheEntry(
             key=f"{self.__class__.__name__}_bulk",
@@ -365,7 +370,7 @@ class DACSource(Source):
         )
 
         # This blocks if another thread is downloading (prevents concurrent waste)
-        bulk_path = self.bulk_cache.ensure(entry, refresh=False)
+        bulk_path = self.bulk_cache.ensure(entry, refresh=refresh)
 
         pyarrow_filters = filters if filters else None
 
@@ -396,6 +401,8 @@ class DACSource(Source):
         using_bulk_download: bool = False,
         additional_filters: list[tuple] | None = None,
         columns: list | None = None,
+        *,
+        refresh: bool = False,
     ):
         """Reads a dataset with 3-tier cache coordination.
 
@@ -408,6 +415,8 @@ class DACSource(Source):
             using_bulk_download: Whether to read from bulk cache
             additional_filters: Additional filters to apply
             columns: Subset of columns to read
+            refresh: If True, bypass the bulk cache and re-download. Only has
+                effect when ``using_bulk_download=True``.
 
         Returns:
             Filtered and cleaned DataFrame
@@ -416,45 +425,49 @@ class DACSource(Source):
         filters = self._get_read_filters(additional_filters=additional_filters)
         param_hash = generate_param_hash(filters if filters else [])
 
-        # 1. Try memory cache (thread-safe, fastest)
-        df = self.memory_cache.get(param_hash)
-        if df is not None:
+        # When refresh=True, skip the upper cache tiers entirely so the bulk
+        # fetcher's refresh=True actually re-downloads and the upper tiers see
+        # the fresh data. Without this guard a warm memory/query cache would
+        # short-circuit the refresh, returning stale data.
+        if not refresh:
+            # 1. Try memory cache (thread-safe, fastest)
+            df = self.memory_cache.get(param_hash)
             # Only use if all requested columns are available
-            if not columns or all(c in df.columns for c in columns):
+            if df is not None and (
+                not columns or all(c in df.columns for c in columns)
+            ):
                 logger.info("Cache hit: memory")
-                return self._apply_columns_and_clean(
-                    df, columns, already_cleaned=True
-                )
+                return self._apply_columns_and_clean(df, columns, already_cleaned=True)
 
-        # For projected reads, also check a projection-specific memory cache
-        if columns:
-            proj_hash = generate_projection_hash(param_hash, columns)
-            df = self.memory_cache.get(proj_hash)
+            # For projected reads, also check a projection-specific memory cache
+            if columns:
+                proj_hash = generate_projection_hash(param_hash, columns)
+                df = self.memory_cache.get(proj_hash)
+                if df is not None:
+                    logger.info("Cache hit: memory (projection)")
+                    return df
+
+            # 2. Try query cache (on-disk parquet, fast)
+            df = self.query_cache.load(
+                self.__class__.__name__, param_hash, None, columns
+            )
             if df is not None:
-                logger.info("Cache hit: memory (projection)")
+                logger.info("Cache hit: query cache")
+                # Only cache in memory if we loaded full data (no column selection)
+                # This way memory cache is reusable for queries with different column subsets
+                if not columns:
+                    self._cache_in_memory(param_hash, df)
+                # Data is already cleaned and column-selected at parquet read level
                 return df
-
-        # 2. Try query cache (on-disk parquet, fast)
-        df = self.query_cache.load(self.__class__.__name__, param_hash, None, columns)
-        if df is not None:
-            logger.info("Cache hit: query cache")
-            # Only cache in memory if we loaded full data (no column selection)
-            # This way memory cache is reusable for queries with different column subsets
-            if not columns:
-                self._cache_in_memory(param_hash, df)
-            # Data is already cleaned and column-selected at parquet read level
-            return df
 
         # 3. Cache miss (query/memory) - need to fetch data
         if using_bulk_download:
             logger.info("Query cache miss - reading from bulk cache")
-            df = self._fetch_from_bulk_cache(filters, columns)
+            df = self._fetch_from_bulk_cache(filters, columns, refresh=refresh)
             if columns:
                 # Cache projected result under a projection-specific key
                 # so it doesn't pollute the shared filter-only cache
-                self._cache_in_memory(
-                    generate_projection_hash(param_hash, columns), df
-                )
+                self._cache_in_memory(generate_projection_hash(param_hash, columns), df)
                 return df
         else:
             # Download via API (uses init-time filters only)
@@ -802,12 +815,15 @@ class AidDataData(AidDataSource):
         self,
         additional_filters: list[tuple] | None = None,
         columns: list | None = None,
+        *,
+        refresh: bool = False,
     ):
         """Reads AidData from bulk cache with filtering.
 
         Args:
             additional_filters: Additional filters to apply
             columns: Subset of columns to read
+            refresh: If True, bypass the bulk cache and re-download.
 
         Returns:
             Filtered DataFrame
@@ -816,34 +832,38 @@ class AidDataData(AidDataSource):
         filters = self._get_read_filters(additional_filters=additional_filters)
         param_hash = generate_param_hash(filters if filters else [])
 
-        # 1. Try memory cache
-        df = self.memory_cache.get(param_hash)
-        if df is not None:
+        # When refresh=True, skip the upper cache tiers so the bulk fetcher's
+        # refresh=True actually re-downloads. See DACSource.read for context.
+        if not refresh:
+            # 1. Try memory cache
+            df = self.memory_cache.get(param_hash)
             # Only use if all requested columns are available
-            if not columns or all(c in df.columns for c in columns):
+            if df is not None and (
+                not columns or all(c in df.columns for c in columns)
+            ):
                 logger.info("Cache hit: memory")
-                return self._apply_columns_and_clean(
-                    df, columns, already_cleaned=True
-                )
+                return self._apply_columns_and_clean(df, columns, already_cleaned=True)
 
-        # For projected reads, also check a projection-specific memory cache
-        if columns:
-            proj_hash = generate_projection_hash(param_hash, columns)
-            df = self.memory_cache.get(proj_hash)
+            # For projected reads, also check a projection-specific memory cache
+            if columns:
+                proj_hash = generate_projection_hash(param_hash, columns)
+                df = self.memory_cache.get(proj_hash)
+                if df is not None:
+                    logger.info("Cache hit: memory (projection)")
+                    return df
+
+            # 2. Try query cache
+            # Use column selection at parquet read level for efficiency
+            df = self.query_cache.load(
+                self.__class__.__name__, param_hash, None, columns
+            )
             if df is not None:
-                logger.info("Cache hit: memory (projection)")
+                logger.info("Cache hit: query cache")
+                # Only cache in memory if we loaded full data (no column selection)
+                if not columns:
+                    self._cache_in_memory(param_hash, df)
+                # Data is already cleaned and column-selected at parquet read level
                 return df
-
-        # 2. Try query cache
-        # Use column selection at parquet read level for efficiency
-        df = self.query_cache.load(self.__class__.__name__, param_hash, None, columns)
-        if df is not None:
-            logger.info("Cache hit: query cache")
-            # Only cache in memory if we loaded full data (no column selection)
-            if not columns:
-                self._cache_in_memory(param_hash, df)
-            # Data is already cleaned and column-selected at parquet read level
-            return df
 
         # 3. Fetch from bulk cache (always bulk for AidData)
         entry = BulkCacheEntry(
@@ -853,7 +873,7 @@ class AidDataData(AidDataSource):
             version=self._get_package_version(),
         )
 
-        bulk_path = self.bulk_cache.ensure(entry, refresh=False)
+        bulk_path = self.bulk_cache.ensure(entry, refresh=refresh)
 
         # Use PyArrow predicate pushdown and column selection for maximum efficiency
         pyarrow_filters = filters if filters else None
@@ -868,9 +888,7 @@ class AidDataData(AidDataSource):
             )
             # Cache under projection-specific key to avoid polluting
             # the shared filter-only cache
-            self._cache_in_memory(
-                generate_projection_hash(param_hash, columns), df
-            )
+            self._cache_in_memory(generate_projection_hash(param_hash, columns), df)
             return df
         else:
             logger.info("Query cache miss - reading from bulk cache")

--- a/src/oda_data/cache/__init__.py
+++ b/src/oda_data/cache/__init__.py
@@ -1,0 +1,38 @@
+"""oda_data.cache — typed cache management surface.
+
+Public symbols re-exported from sub-modules:
+
+- ``path``, ``entries``, ``clear``, ``size``, ``invalidate``,
+  ``enable_cache``, ``disable_cache`` — from :mod:`oda_data.cache.api`
+- ``migrate`` — from :mod:`oda_data.cache._migrate`
+- ``set_cache_root`` — from :mod:`oda_data.cache.config`
+- ``CacheRecord``, ``MigrationResult``, ``Scope`` — from :mod:`oda_data.cache.types`
+"""
+
+from oda_data.cache._migrate import migrate
+from oda_data.cache.api import (
+    clear,
+    disable_cache,
+    enable_cache,
+    entries,
+    invalidate,
+    path,
+    size,
+)
+from oda_data.cache.config import set_cache_root
+from oda_data.cache.types import CacheRecord, MigrationResult, Scope
+
+__all__ = [
+    "CacheRecord",
+    "MigrationResult",
+    "Scope",
+    "clear",
+    "disable_cache",
+    "enable_cache",
+    "entries",
+    "invalidate",
+    "migrate",
+    "path",
+    "set_cache_root",
+    "size",
+]

--- a/src/oda_data/cache/_migrate.py
+++ b/src/oda_data/cache/_migrate.py
@@ -1,0 +1,388 @@
+"""Cache auto-migration from pre-2.6 layouts.
+
+Detects old cache trees (CWD .raw_data, oda-reader platformdirs defaults,
+Windows LOCALAPPDATA) and moves/copies their contents into the unified 2.6
+cache root.
+
+Synced-drive parents are skipped unless ``force=True``. Cross-volume moves
+fall back to copy2 + verify + unlink. All operations are idempotent via a
+``.migrated_to`` breadcrumb written at the old root after a successful
+migration.
+"""
+
+import errno
+import logging
+import os
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+
+from oda_data.cache.config import oda_data_cache_root
+from oda_data.cache.types import MigrationResult
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Synced-drive detection
+# ---------------------------------------------------------------------------
+
+# File/dir markers that indicate Dropbox ownership (checked in any ancestor).
+_DROPBOX_MARKERS: frozenset[str] = frozenset({".dropbox", ".dropbox.cache"})
+
+# File/dir markers that indicate iCloud ownership (checked in any ancestor).
+# Note: Apple uses camelCase on disk; the brief's lowercase form was loose.
+_ICLOUD_MARKERS: frozenset[str] = frozenset({"com.apple.iCloud"})
+
+# Union precomputed once so the ancestor-walk loop does not rebuild it each step.
+_FILE_MARKERS: frozenset[str] = _DROPBOX_MARKERS | _ICLOUD_MARKERS
+
+# Prefix that identifies OneDrive path-segments (segment equality or prefix).
+_ONEDRIVE_EXACT: str = "OneDrive"
+_ONEDRIVE_PREFIX: str = "OneDrive - "
+
+
+def _find_synced_marker(path: Path) -> str | None:
+    """Return a human-readable description of the synced-drive marker, or None.
+
+    Checks *path* and its ancestors up to (and including) the home directory.
+    Returns ``None`` when no synced-drive marker is found.
+
+    Args:
+        path: Directory to check.
+
+    Returns:
+        Short description string (e.g. ``"iCloud (Mobile Documents)"``,
+        ``"/home/user/.dropbox"``) when a marker is found, else ``None``.
+    """
+    home = Path.home()
+
+    # iCloud Mobile Documents — path membership check (no filesystem access).
+    try:
+        path.relative_to(home / "Library" / "Mobile Documents")
+        return "iCloud (Mobile Documents)"
+    except ValueError:
+        pass
+
+    # Walk ancestors up to (but not past) the home directory.
+    current = path.resolve()
+    stop = home.resolve()
+
+    while True:
+        # Dropbox and iCloud file/dir markers.
+        for marker in _FILE_MARKERS:
+            candidate = current / marker
+            if candidate.exists():
+                return str(candidate)
+
+        # OneDrive path-segment check (no per-folder marker file).
+        for part in current.parts:
+            if part == _ONEDRIVE_EXACT or part.startswith(_ONEDRIVE_PREFIX):
+                return f"OneDrive segment '{part}'"
+
+        if current in (stop, current.parent):
+            break
+        current = current.parent
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Cross-volume detection
+# ---------------------------------------------------------------------------
+
+
+def _is_cross_volume(src: Path, dst_parent: Path) -> bool:
+    """Return True when *src* and *dst_parent* live on different volumes.
+
+    This is the single boundary for cross-volume detection. Tests inject a
+    replacement via the ``is_cross_volume`` parameter on ``_migrate_tree``
+    instead of monkeypatching ``os.stat`` globally (which would corrupt
+    ``shutil.move``'s own device checks).
+
+    Args:
+        src: Source directory being migrated.
+        dst_parent: Parent of the destination directory.
+
+    Returns:
+        True when the two paths are on different block devices.
+    """
+    return src.stat().st_dev != dst_parent.stat().st_dev
+
+
+# ---------------------------------------------------------------------------
+# Old cache root detection
+# ---------------------------------------------------------------------------
+
+
+def _old_cache_paths_to_scan() -> list[Path]:
+    """Return the candidate pre-2.6 cache roots that exist on disk.
+
+    Returns:
+        Existing paths from the fixed detection set: CWD/.raw_data, two
+        oda-reader platformdirs defaults, and the Windows LOCALAPPDATA path.
+    """
+    candidates = [
+        Path.cwd() / ".raw_data",
+        Path("~/Library/Caches/oda-reader").expanduser(),
+        Path("~/.cache/oda-reader").expanduser(),
+    ]
+    if local_app_data := os.environ.get("LOCALAPPDATA"):
+        candidates.append(Path(local_app_data) / "oda-reader" / "Cache")
+    return [p for p in candidates if p.exists()]
+
+
+# ---------------------------------------------------------------------------
+# Breadcrumb helpers
+# ---------------------------------------------------------------------------
+
+
+def _already_migrated(old_root: Path) -> bool:
+    """Return True if a ``.migrated_to`` breadcrumb exists at *old_root*."""
+    return (old_root / ".migrated_to").exists()
+
+
+def _write_breadcrumb(old_root: Path, new_root: Path) -> None:
+    """Write a ``.migrated_to`` breadcrumb at *old_root* pointing to *new_root*.
+
+    Args:
+        old_root: Source cache tree root.
+        new_root: Destination cache tree root (absolute path written to the file).
+    """
+    (old_root / ".migrated_to").write_text(f"{new_root.resolve()}\n")
+
+
+# ---------------------------------------------------------------------------
+# Tree migration
+# ---------------------------------------------------------------------------
+
+
+def _migrate_tree(
+    src: Path,
+    dst: Path,
+    *,
+    force: bool,
+    is_cross_volume: Callable[[Path, Path], bool] = _is_cross_volume,
+) -> MigrationResult:
+    """Migrate one old cache tree from *src* to *dst*.
+
+    Steps (in order):
+    1. Synced-drive guard — skip unless ``force=True``.
+    2. Volume comparison — same-volume → ``shutil.move``; cross-volume →
+       ``shutil.copy2`` + size-verify + ``unlink``.
+    3. ``OSError(errno 28)`` (ENOSPC) → skipped_disk_full.
+    4. Generic ``OSError`` → failed.
+
+    Args:
+        src: Old cache tree root directory.
+        dst: Destination directory (will be created if absent).
+        force: If True, the synced-drive guard is disabled.
+        is_cross_volume: Predicate injected for testability. Default uses
+            ``os.stat().st_dev`` comparison.
+
+    Returns:
+        A ``MigrationResult`` describing the outcome.
+    """
+    # --- synced-drive guard --------------------------------------------------
+    marker_desc = None if force else _find_synced_marker(src)
+    if marker_desc is not None:
+        return MigrationResult(
+            source=src,
+            status="skipped_synced_drive",
+            files_moved=0,
+            bytes_moved=0,
+            message=(
+                f"Skipped: {src} appears to be on a synced drive "
+                f"({marker_desc}). Run migrate(force=True) to override."
+            ),
+        )
+
+    # --- collect source files ------------------------------------------------
+    src_files = [f for f in src.rglob("*") if f.is_file()]
+    if not src_files:
+        # Empty tree — treat as successful with zero counts.
+        _write_breadcrumb(src, dst)
+        return MigrationResult(
+            source=src,
+            status="migrated",
+            files_moved=0,
+            bytes_moved=0,
+            message=f"Migrated 0 files from {src} to {dst} (empty tree).",
+        )
+
+    dst.mkdir(parents=True, exist_ok=True)
+    cross_vol = is_cross_volume(src, dst.parent)
+
+    if cross_vol:
+        log.info(
+            "Cross-volume migration from %s to %s — "
+            "this may take a few minutes for ~1 GB.",
+            src,
+            dst,
+        )
+
+    files_moved = 0
+    bytes_moved = 0
+
+    try:
+        for src_file in src_files:
+            rel = src_file.relative_to(src)
+            dst_file = dst / rel
+            dst_file.parent.mkdir(parents=True, exist_ok=True)
+
+            src_size = src_file.stat().st_size
+
+            if cross_vol:
+                shutil.copy2(src_file, dst_file)
+                # Verify size before unlinking the source.
+                dst_size = dst_file.stat().st_size
+                if dst_size != src_size:
+                    dst_file.unlink(missing_ok=True)
+                    raise OSError(
+                        f"Size mismatch after copy: {src_file} ({src_size} B) "
+                        f"!= {dst_file} ({dst_size} B)"
+                    )
+                src_file.unlink()
+            else:
+                shutil.move(str(src_file), dst_file)
+
+            files_moved += 1
+            bytes_moved += src_size
+
+    except OSError as exc:
+        if exc.errno == errno.ENOSPC:
+            log.warning(
+                "Disk full while migrating %s → %s. "
+                "Both old and new trees are left in place. "
+                "Free up space and re-run migrate().",
+                src,
+                dst,
+            )
+            return MigrationResult(
+                source=src,
+                status="skipped_disk_full",
+                files_moved=files_moved,
+                bytes_moved=bytes_moved,
+                message=f"Disk full (ENOSPC): {exc}",
+            )
+        log.warning("Migration failed for %s: %s", src, exc)
+        return MigrationResult(
+            source=src,
+            status="failed",
+            files_moved=files_moved,
+            bytes_moved=bytes_moved,
+            message=str(exc),
+        )
+
+    _write_breadcrumb(src, dst)
+    return MigrationResult(
+        source=src,
+        status="migrated",
+        files_moved=files_moved,
+        bytes_moved=bytes_moved,
+        message=f"Migrated {files_moved} file(s) ({bytes_moved} B) from {src} to {dst}.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Destination mapping
+# ---------------------------------------------------------------------------
+
+# Maps old cache-root stems (after stripping leading dots) to the canonical 2.6
+# subtree under new_root.  Old .raw_data goes to oda-data/ (where
+# BulkCacheManager and QueryCacheManager look); old oda-reader trees stay under
+# oda-reader/ (matching oda_reader._cache.config's subdirectory names).
+_DST_MAP: dict[str, str] = {
+    "raw_data": "oda-data",
+    "oda-reader": "oda-reader",
+}
+
+
+def _canonical_dst(old_root: Path, new_root: Path) -> Path:
+    """Return the canonical 2.6 destination for *old_root*.
+
+    For recognised old-root names, maps directly to the canonical subtree.
+    Falls back to ``new_root / old_root.name.lstrip('.')`` for unknown names.
+
+    Args:
+        old_root: The old cache root being migrated.
+        new_root: The new 2.6 cache root.
+
+    Returns:
+        Destination directory path under *new_root*.
+    """
+    stem = old_root.name.lstrip(".")
+    subtree = _DST_MAP.get(stem, stem)
+    return new_root / subtree
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def _check_downgrade_breadcrumb(new_root: Path) -> None:
+    """Raise RuntimeError if a downgrade breadcrumb is found at *new_root*.
+
+    A ``.migrated_to`` breadcrumb at the new root means this directory was
+    *itself* a source that was migrated elsewhere (i.e. the user downgraded
+    after a migration).  Running with a stale, partially-consumed cache in
+    that state would produce confusing behaviour.
+
+    Args:
+        new_root: The resolved 2.6 cache root.
+
+    Raises:
+        RuntimeError: If ``.migrated_to`` exists at *new_root*.
+    """
+    breadcrumb = new_root / ".migrated_to"
+    if breadcrumb.exists():
+        destination = breadcrumb.read_text().strip()
+        raise RuntimeError(
+            f"Cache at {new_root} was already migrated to {destination}. "
+            "It looks like oda_data was downgraded after a successful migration. "
+            "Upgrade to oda_data>=2.6 or delete the old cache directory and "
+            "re-run to start fresh."
+        )
+
+
+def migrate(*, force: bool = False) -> list[MigrationResult]:
+    """Migrate any pre-2.6 cache directories to the unified cache root.
+
+    Detects four old layouts (CWD ``.raw_data``, two oda-reader platformdirs
+    defaults, Windows LOCALAPPDATA) and copies/moves their contents.
+    Synced-drive parents are skipped unless ``force=True``.
+
+    Args:
+        force: If True, bypass the synced-drive guard. Cross-volume
+            detection is preserved.
+
+    Returns:
+        One ``MigrationResult`` per detected source root. Status enumerates the
+        outcome (``"migrated"``, ``"skipped_synced_drive"``,
+        ``"skipped_already_migrated"``, ``"skipped_disk_full"``,
+        ``"failed"``).
+    """
+    new_root = oda_data_cache_root()
+    _check_downgrade_breadcrumb(new_root)
+    results: list[MigrationResult] = []
+
+    for old_root in _old_cache_paths_to_scan():
+        if _already_migrated(old_root):
+            results.append(
+                MigrationResult(
+                    source=old_root,
+                    status="skipped_already_migrated",
+                    files_moved=0,
+                    bytes_moved=0,
+                    message=f"Already migrated (breadcrumb exists at {old_root / '.migrated_to'}).",
+                )
+            )
+            continue
+
+        # Map each old root to the canonical 2.6 destination layout so that
+        # BulkCacheManager / QueryCacheManager can find the files after migration.
+        dst = _canonical_dst(old_root, new_root)
+        result = _migrate_tree(old_root, dst, force=force)
+        results.append(result)
+
+    return results

--- a/src/oda_data/cache/api.py
+++ b/src/oda_data/cache/api.py
@@ -1,0 +1,513 @@
+"""Implementation of the oda_data.cache public API.
+
+Functions here aggregate oda_data's own bulk/query caches and oda_reader's
+http/raw caches into a single Scope-keyed view.
+"""
+
+import contextlib
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from oda_data.cache.config import oda_data_cache_root
+from oda_data.cache.types import CacheRecord, Scope, _validate_scope
+from oda_data.logger import logger
+
+if TYPE_CHECKING:
+    from oda_data.api.sources import Source
+
+# Scopes that belong to oda_data's own disk layout.
+_ODA_DATA_SCOPES: tuple[str, ...] = ("bulk", "query")
+# Leaf sub-directory names inside cache_root / "oda-data".
+_SCOPE_SUBDIR: dict[str, str] = {
+    "bulk": "bulk_cache",
+    "query": "query_cache",
+}
+# All concrete scopes (never "all") — immutable constant, not rebuilt on each call.
+_ALL_SCOPES: tuple[str, ...] = ("bulk", "query", "http", "raw")
+
+# ── Per-scope enable/disable flags ──────────────────────────────────────────
+_SCOPE_ENABLED: dict[str, bool] = {
+    "bulk": True,
+    "query": True,
+    "http": True,
+    "raw": True,
+}
+
+# ── 5 GB stale-cache warning gate ───────────────────────────────────────────
+_WARNED_STALE_5GB: bool = False
+_5GB = 5 * 2**30  # bytes
+
+
+def _oda_data_cache_dir() -> Path:
+    """Return the oda-data sub-tree of the resolved cache root."""
+    return oda_data_cache_root() / "oda-data"
+
+
+def _scope_dir(scope: str) -> Path:
+    """Return the directory for an oda_data-owned scope."""
+    subdir = _SCOPE_SUBDIR[scope]
+    return _oda_data_cache_dir() / subdir
+
+
+def _oda_reader_cache_dir() -> Path:
+    """Return the oda-reader sub-tree of the resolved cache root."""
+    return oda_data_cache_root() / "oda-reader"
+
+
+# Maps logical scope names to the actual subdirectory names oda_reader uses on
+# disk.  oda_reader._cache.config uses "http_cache" and "bulk_files"; these
+# must match so cache.clear("raw") actually removes the right files.
+_ODA_READER_SUBDIR: dict[str, str] = {
+    "http": "http_cache",
+    "raw": "bulk_files",
+}
+
+# oda_reader sub-directories that are NOT backed by a public Scope literal but
+# are still wiped by ``clear("all")``. Today only ``dataframes`` (oda_reader's
+# processed-DataFrame cache); future additions go here so the "all" sweep
+# stays exhaustive.
+_ODA_READER_EXTRA_SUBDIRS: tuple[str, ...] = ("dataframes",)
+
+
+def _dir_size(directory: Path) -> int:
+    """Return the total byte size of all files under *directory* (recursive)."""
+    if not directory.is_dir():
+        return 0
+    total = 0
+    for f in directory.rglob("*"):
+        if f.is_file():
+            with contextlib.suppress(OSError):
+                total += f.stat().st_size
+    return total
+
+
+# ── Public API ───────────────────────────────────────────────────────────────
+
+
+def path(scope: Scope = "all") -> Path:
+    """Return the cache root, or the directory for a specific scope.
+
+    Note: ``'all'`` returns the cache root (containing ``oda-data/`` and
+    ``oda-reader/`` sub-trees); per-scope values return their leaf directory.
+
+    Args:
+        scope: One of {"all", "bulk", "query", "http", "raw"}. "all" returns
+            the unified cache root.
+
+    Returns:
+        Absolute path to the requested directory.
+
+    Raises:
+        ValueError: If ``scope`` is not one of the Scope literals.
+    """
+    _validate_scope(scope)
+    if scope == "all":
+        return oda_data_cache_root()
+    if scope in _ODA_DATA_SCOPES:
+        return _scope_dir(scope)
+    # http / raw live under the oda-reader sub-tree with different leaf names.
+    return _oda_reader_cache_dir() / _ODA_READER_SUBDIR[scope]
+
+
+def entries() -> dict[Scope, list[CacheRecord]]:
+    """Return all cache records grouped by scope.
+
+    Returns:
+        Mapping from each scope (excluding "all") to its CacheRecord list.
+        Empty list for scopes with no files.
+    """
+    root = oda_data_cache_root()
+    oda_data_dir = root / "oda-data"
+    reader_dir = root / "oda-reader"
+    now = time.time()
+    result: dict[Scope, list[CacheRecord]] = {}
+
+    for scope_name in _ALL_SCOPES:
+        if scope_name in _ODA_DATA_SCOPES:
+            directory = oda_data_dir / _SCOPE_SUBDIR[scope_name]
+        else:
+            directory = reader_dir / _ODA_READER_SUBDIR[scope_name]
+
+        scope_records: list[CacheRecord] = []
+        if directory.is_dir():
+            for f in directory.iterdir():
+                if not f.is_file():
+                    continue
+                try:
+                    st = f.stat()
+                    age_days = (now - st.st_mtime) / 86400.0
+                    scope_records.append(
+                        CacheRecord(
+                            key=f.stem,
+                            path=f,
+                            size_bytes=st.st_size,
+                            age_days=round(age_days, 3),
+                            version="",
+                            scope=scope_name,  # type: ignore[arg-type]
+                        )
+                    )
+                except OSError:
+                    pass
+
+        result[scope_name] = scope_records  # type: ignore[index]
+
+    return result
+
+
+def clear(scope: Scope = "all", *, blocking: bool = True) -> dict[Scope, int | None]:
+    """Delete cached files in the named scope.
+
+    Args:
+        scope: Which scope to clear. "all" clears every scope.
+        blocking: If True (default), acquire the FileLock and wait up to the
+            lock timeout. If False, skip scopes under contention.
+
+    Returns:
+        Mapping from each scope to the count of files deleted, or ``None`` if
+        the scope was skipped due to lock contention. ``0`` means the scope was
+        reachable but empty.
+
+        Note: The ``None`` return sentinel applies only to the ``"bulk"`` and
+        ``"query"`` scopes, which ``oda_data`` writes under a ``FileLock``.
+        For ``"http"`` and ``"raw"`` (owned by ``oda_reader``), the returned
+        value is always an ``int`` regardless of ``blocking``: every reachable
+        file is unlinked, but contention with a concurrent ``oda_reader``
+        writer cannot currently be detected. If you need a strict "no clears
+        during active writes" guarantee for those scopes, coordinate at the
+        call-site level (e.g., quiesce in-flight downloads first).
+
+    Raises:
+        ValueError: If ``scope`` is not one of the Scope literals.
+    """
+    _validate_scope(scope)
+    scopes_to_clear = _ALL_SCOPES if scope == "all" else [scope]
+    result: dict[Scope, int | None] = {}
+
+    for s in scopes_to_clear:
+        count = _clear_one_scope(s, blocking=blocking)
+        result[s] = count  # type: ignore[index]
+
+    # clear("all") must leave nothing behind under the oda-reader sub-tree;
+    # sweep extras (e.g. dataframes) and fold their count into "raw" so the
+    # public return type stays unchanged.
+    if scope == "all":
+        extra = _clear_oda_reader_extra_subdirs()
+        if extra and isinstance(result.get("raw"), int):
+            result["raw"] = result["raw"] + extra  # type: ignore[operator]
+
+    return result
+
+
+def _clear_oda_reader_extra_subdirs() -> int:
+    """Wipe oda_reader subdirs not backed by a public Scope (e.g. dataframes).
+
+    Returns the number of files deleted. Best-effort: ``oda_reader`` does not
+    expose lock paths for these subdirs.
+    """
+    base = _oda_reader_cache_dir()
+    count = 0
+    for subdir_name in _ODA_READER_EXTRA_SUBDIRS:
+        directory = base / subdir_name
+        if not directory.is_dir():
+            continue
+        for f in list(directory.rglob("*")):
+            if f.is_file():
+                try:
+                    f.unlink()
+                    count += 1
+                except OSError as e:
+                    logger.warning(f"Failed to delete {f}: {e}")
+    return count
+
+
+def _clear_one_scope(scope_name: str, *, blocking: bool) -> int | None:
+    """Clear a single scope; returns file count or None on contention."""
+    if scope_name in _ODA_DATA_SCOPES:
+        return _clear_oda_data_scope(scope_name, blocking=blocking)
+    return _clear_oda_reader_scope(scope_name, blocking=blocking)
+
+
+def _clear_oda_data_scope(scope_name: str, *, blocking: bool) -> int | None:
+    """Clear an oda_data-owned scope (bulk or query)."""
+    directory = _scope_dir(scope_name)
+    if not directory.is_dir():
+        return 0
+
+    from filelock import FileLock, Timeout
+
+    lock_name = ".cache.lock" if scope_name == "bulk" else ".query.lock"
+    lock_path = directory / lock_name
+    lock_timeout = 1200 if blocking else 0
+
+    try:
+        with FileLock(str(lock_path), timeout=lock_timeout):
+            count = 0
+            for f in list(directory.iterdir()):
+                if f.is_file() and f.suffix in (".parquet", ".json"):
+                    try:
+                        f.unlink()
+                        count += 1
+                    except OSError as e:
+                        logger.warning(f"Failed to delete {f}: {e}")
+            return count
+    except Timeout:
+        logger.debug(f"Skipping scope {scope_name!r}: lock held by another process.")
+        return None
+
+
+def _clear_oda_reader_scope(scope_name: str, *, blocking: bool) -> int | None:
+    """Clear an oda_reader-owned scope (http or raw).
+
+    ``oda_reader`` does not currently expose a public lock path for these
+    scopes, so ``blocking`` is accepted for signature parity but cannot be
+    honoured. Every reachable file is unlinked; the function always returns
+    an ``int`` (never ``None``).
+    """
+    # TODO(jorge 2026-04-28): switch to FileLock once oda_reader publishes a
+    # public lock-path getter for the http/raw caches.
+    directory = _oda_reader_cache_dir() / _ODA_READER_SUBDIR[scope_name]
+    if not directory.is_dir():
+        return 0
+
+    count = 0
+    for f in list(directory.rglob("*")):
+        if f.is_file():
+            try:
+                f.unlink()
+                count += 1
+            except OSError as e:
+                logger.warning(f"Failed to delete {f}: {e}")
+    return count
+
+
+def size() -> dict[Scope, int]:
+    """Return cache size per scope, in bytes.
+
+    Side effect: if the total bytes across the current cache root **and** every
+    sibling version-segmented subtree exceeds 5 GB, logs one WARNING per
+    process.
+
+    Returns:
+        Mapping from each scope (excluding "all") to size in bytes.
+    """
+    global _WARNED_STALE_5GB
+
+    # Resolve root once to avoid repeated calls across the loop + stale check.
+    root = oda_data_cache_root()
+    oda_data_dir = root / "oda-data"
+    reader_dir = root / "oda-reader"
+
+    result: dict[Scope, int] = {}
+    for s in _ALL_SCOPES:
+        if s in _ODA_DATA_SCOPES:
+            d = oda_data_dir / _SCOPE_SUBDIR[s]
+        else:
+            d = reader_dir / _ODA_READER_SUBDIR[s]
+        result[s] = _dir_size(d)  # type: ignore[index]
+
+    if not _WARNED_STALE_5GB:
+        total = _stale_total_bytes(root)
+        if total > _5GB:
+            _WARNED_STALE_5GB = True
+            logger.warning(
+                f"Total ODA cache size (including older-version caches at "
+                f"{root.parent}) exceeds 5 GB ({total / 2**30:.1f} GB). "
+                'Run oda_data.cache.clear(scope="raw") to free space, or delete '
+                "older-version directories manually."
+            )
+
+    return result
+
+
+def _stale_total_bytes(current: Path) -> int:
+    """Sum bytes across *current* and all sibling-version subtrees.
+
+    Args:
+        current: The resolved cache root for this process.
+    """
+    parent = current.parent  # e.g. <platformdirs>/oda-data/
+    if not parent.is_dir():
+        return _dir_size(current)
+    total = 0
+    for child in parent.iterdir():
+        if child.is_dir():
+            total += _dir_size(child)
+    return total
+
+
+def invalidate(dataset: "type[Source] | str") -> None:
+    """Invalidate cache entries for a single dataset (always blocking).
+
+    Blocking semantics: acquires the bulk and query write locks (60-second
+    timeout each) so the unlink sequence cannot race with concurrent writers.
+    Callers that already hold either lock will deadlock against themselves or
+    hit ``filelock.Timeout`` — do not call ``cache.invalidate`` from inside a
+    ``BulkCacheManager`` or ``QueryCacheManager`` write context (e.g. a
+    fetcher callback).
+
+    On ``filelock.Timeout``, retry after the current writer completes;
+    persistent timeouts indicate a stuck process and may require a manual
+    ``cache.clear()``.
+
+    Args:
+        dataset: Either a Source subclass (e.g. ``CRSData``) or its class
+            ``__name__`` as a string (e.g. ``"CRSData"``). The string must
+            match the class name exactly — lowercase or partial names are
+            rejected.
+
+    Raises:
+        ValueError: If ``dataset`` is a string that does not match any
+            registered Source subclass ``__name__``.
+        filelock.Timeout: If a write lock cannot be acquired within 60
+            seconds.
+    """
+    from oda_data.api.sources import Source as _Source
+
+    name = dataset if isinstance(dataset, str) else dataset.__name__
+
+    # Build the registry from all known Source subclasses.
+    known: dict[str, type[_Source]] = {
+        cls.__name__: cls for cls in _all_source_subclasses(_Source)
+    }
+
+    if name not in known:
+        valid = sorted(known)
+        raise ValueError(
+            f"Unknown dataset {name!r}. "
+            f"Expected one of: {valid}. "
+            f"Note: names are case-sensitive and must match the class __name__ exactly."
+        )
+
+    # Remove matching bulk and query entries.
+    bulk_key = f"{name}_bulk"
+    _invalidate_bulk_entry(bulk_key)
+    _invalidate_query_entries(name)
+
+
+def _all_source_subclasses(base: type) -> list[type]:
+    """Recursively collect all concrete subclasses of *base*."""
+    result = []
+    for sub in base.__subclasses__():
+        result.append(sub)
+        result.extend(_all_source_subclasses(sub))
+    return result
+
+
+def _invalidate_bulk_entry(key: str) -> None:
+    """Remove a single bulk parquet file and its manifest entry.
+
+    Reuses ``Source._shared_bulk_cache`` when its base directory matches the
+    current cache root, so callers that already hold the bulk lock on that
+    singleton (e.g. a fetcher callback) do not deadlock against a fresh
+    ``FileLock`` instance pointing at the same path. Falls back to a brand-new
+    manager when no singleton has been initialised yet — cross-process
+    coordination is preserved either way (same lock-file path).
+    """
+    from oda_data.api.sources import Source
+    from oda_data.tools.cache import BulkCacheManager
+
+    target_root = _oda_data_cache_dir()
+    mgr = Source._shared_bulk_cache
+    if mgr is None or mgr.base_dir.parent != target_root:
+        mgr = BulkCacheManager(target_root)
+    mgr.clear(key=key)
+    orphan = _scope_dir("bulk") / f"{key}.parquet"
+    orphan.unlink(missing_ok=True)
+
+
+def _invalidate_query_entries(dataset_name: str) -> None:
+    """Remove all query-cache files whose name starts with *dataset_name*.
+
+    Acquires ``.query.lock`` (timeout 60 s) so the unlink loop cannot race
+    with concurrent ``QueryCacheManager.save``. This realises the
+    ``cache.invalidate`` "always blocking" contract.
+    """
+    from filelock import FileLock
+
+    query_dir = _scope_dir("query")
+    if not query_dir.is_dir():
+        return
+    lock_path = query_dir / ".query.lock"
+    prefix = f"{dataset_name}-"
+    # 60 s timeout is intentional: invalidate is a single-dataset operation,
+    # not a full cache wipe. cache.clear's 1200 s timeout fits a slower
+    # whole-cache sweep; 60 s here keeps invalidate from blocking a CLI
+    # session indefinitely if a writer is wedged.
+    with FileLock(str(lock_path), timeout=60):
+        for f in list(query_dir.iterdir()):
+            if f.is_file() and f.name.startswith(prefix):
+                try:
+                    f.unlink()
+                except OSError as e:
+                    logger.warning(f"Failed to delete query cache {f}: {e}")
+
+
+def enable_cache(scope: Scope = "all") -> None:
+    """Enable caching for the named scope.
+
+    Args:
+        scope: Which scope to enable. "all" enables every scope.
+
+    Note:
+        ``"http"`` and ``"raw"`` share a single underlying toggle in
+        ``oda_reader``: enabling either enables both. ``oda_data`` mirrors
+        the coupling in its own per-scope flags so ``is_scope_enabled``
+        reports a consistent state on both sides.
+
+    Raises:
+        ValueError: If ``scope`` is not one of the Scope literals.
+    """
+    _validate_scope(scope)
+    _set_scope_enabled(scope, enabled=True)
+
+
+def disable_cache(scope: Scope = "all") -> None:
+    """Disable caching for the named scope.
+
+    Args:
+        scope: Which scope to disable. "all" disables every scope.
+
+    Note:
+        ``"http"`` and ``"raw"`` share a single underlying toggle in
+        ``oda_reader``: disabling either disables both. ``oda_data`` mirrors
+        the coupling in its own per-scope flags so ``is_scope_enabled``
+        reports a consistent state on both sides.
+
+    Raises:
+        ValueError: If ``scope`` is not one of the Scope literals.
+    """
+    _validate_scope(scope)
+    _set_scope_enabled(scope, enabled=False)
+
+
+def _set_scope_enabled(scope: str, *, enabled: bool) -> None:
+    scopes: list[str] = list(_ALL_SCOPES) if scope == "all" else [scope]
+
+    # http and raw share a single oda_reader-side toggle; mirror that in
+    # _SCOPE_ENABLED so toggling one scope does not leave the other in a
+    # state that contradicts the underlying truth on disk.
+    if scope != "all" and ("http" in scopes or "raw" in scopes):
+        scopes = list({*scopes, "http", "raw"})
+
+    for s in scopes:
+        _SCOPE_ENABLED[s] = enabled
+
+    reader_scopes = [s for s in scopes if s in ("http", "raw")]
+    if reader_scopes:
+        try:
+            import oda_reader
+
+            if enabled:
+                oda_reader.enable_cache()
+            else:
+                oda_reader.disable_cache()
+        except Exception as e:
+            logger.debug(
+                f"Could not toggle oda_reader cache for scopes {reader_scopes!r}: {e}"
+            )
+
+
+def is_scope_enabled(scope: str) -> bool:
+    """Return True if *scope* is currently enabled (internal helper)."""
+    return _SCOPE_ENABLED.get(scope, True)

--- a/src/oda_data/cache/config.py
+++ b/src/oda_data/cache/config.py
@@ -1,0 +1,114 @@
+"""Cache-root resolution for oda_data.
+
+Priority: set_cache_root() override > ODA_DATA_CACHE_DIR env var >
+platformdirs default (user_cache_dir("oda-data") / __version__).
+"""
+
+import os
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+from pathlib import Path
+
+import platformdirs
+
+from oda_data.logger import logger
+
+try:
+    _PACKAGE_VERSION = _pkg_version("oda_data")
+except PackageNotFoundError:
+    _PACKAGE_VERSION = "0.0.0"
+
+_cache_root_override: Path | None = None
+_LAST_CHAINED_ROOT: Path | None = None
+_AUTO_MIGRATED: bool = False
+
+
+def _resolve_cache_root() -> Path:
+    """Return the effective cache root without side effects."""
+    if _cache_root_override is not None:
+        return _cache_root_override
+    env = os.environ.get("ODA_DATA_CACHE_DIR")
+    if env:
+        return Path(env).resolve()
+    return Path(platformdirs.user_cache_dir("oda-data")) / _PACKAGE_VERSION
+
+
+def _chain_oda_reader_cache(root: Path) -> None:
+    """Forward the resolved cache root to oda_reader — once per unique root.
+
+    Short-circuits when the root equals the last-chained value so repeated
+    calls to oda_data_cache_root() are cheap.
+    """
+    global _LAST_CHAINED_ROOT
+
+    if root == _LAST_CHAINED_ROOT:
+        return
+
+    import oda_reader
+
+    oda_reader.set_cache_dir(root / "oda-reader")
+    _LAST_CHAINED_ROOT = root
+
+
+def _auto_migrate_once() -> None:
+    """Run auto-migration on first call per process.
+
+    Imports ``migrate`` lazily to avoid a circular-import at module load time
+    (``migrate.py`` imports ``oda_data_cache_root`` from this module).
+
+    Exception policy:
+      - ``RuntimeError`` propagates (intentional downgrade-detection failure
+        from ``_check_downgrade_breadcrumb``).
+      - Any other exception is logged at WARNING and swallowed; auto-migration
+        will not retry this session, but the user's first cache access still
+        succeeds.
+    """
+    global _AUTO_MIGRATED
+
+    if _AUTO_MIGRATED:
+        return
+    _AUTO_MIGRATED = True
+
+    from oda_data.cache._migrate import migrate as _do_migrate
+
+    try:
+        _do_migrate(force=False)
+    except RuntimeError:
+        # Downgrade-detection — propagate intentionally (loud failure is the design).
+        raise
+    except Exception as exc:
+        # Transient migration failure (filesystem error, etc.) must not break
+        # first-touch cache access. Log and continue without migration.
+        logger.warning(
+            f"Cache auto-migration failed; continuing without migration: {exc}"
+        )
+
+
+def oda_data_cache_root() -> Path:
+    """Resolve the cache root.
+
+    Priority: set_cache_root() override > ODA_DATA_CACHE_DIR env var >
+    platformdirs default.
+
+    Side effects (cheap, idempotent):
+    - Chains the resolved root to oda_reader via _chain_oda_reader_cache().
+    - Runs auto-migration on the first call per process via _auto_migrate_once().
+
+    Returns:
+        Absolute path to the cache root.
+    """
+    root = _resolve_cache_root()
+    _chain_oda_reader_cache(root)
+    _auto_migrate_once()
+    return root
+
+
+def set_cache_root(path: str | Path) -> None:
+    """Set a custom cache root, taking precedence over env var and default.
+
+    Args:
+        path: Directory to use as the cache root. Created on first use.
+    """
+    global _cache_root_override
+
+    _cache_root_override = Path(path).resolve()

--- a/src/oda_data/cache/types.py
+++ b/src/oda_data/cache/types.py
@@ -1,0 +1,70 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, get_args
+
+Scope = Literal["all", "bulk", "query", "http", "raw"]
+_SCOPE_VALUES: tuple[str, ...] = get_args(Scope)
+
+
+@dataclass(frozen=True, slots=True)
+class CacheRecord:
+    """One row in oda_data.cache.entries().
+
+    Attributes:
+        key: Cache entry identifier (e.g., "CRSData_bulk").
+        path: Absolute path to the cached file.
+        size_bytes: On-disk size in bytes.
+        age_days: Days since the entry was downloaded.
+        version: Package version recorded when the entry was created.
+        scope: Which cache scope owns this entry.
+    """
+
+    key: str
+    path: Path
+    size_bytes: int
+    age_days: float
+    version: str
+    scope: Scope
+
+
+@dataclass(frozen=True, slots=True)
+class MigrationResult:
+    """Outcome of migrating one pre-2.6 cache tree.
+
+    Attributes:
+        source: Old cache tree root that was scanned.
+        status: Outcome category.
+        files_moved: Count of files moved (0 for skipped/failed).
+        bytes_moved: Total bytes moved (0 for skipped/failed).
+        message: Human-readable detail (e.g. path of the synced-drive marker
+            that triggered a skip, or the OSError message on failure).
+    """
+
+    source: Path
+    status: Literal[
+        "migrated",
+        "skipped_synced_drive",
+        "skipped_already_migrated",
+        "skipped_disk_full",
+        "failed",
+    ]
+    files_moved: int
+    bytes_moved: int
+    message: str
+
+
+def _validate_scope(scope: object) -> Scope:
+    """Raise ValueError if scope is not a known Scope literal.
+
+    Args:
+        scope: Value to validate.
+
+    Returns:
+        The same value, narrowed to Scope.
+
+    Raises:
+        ValueError: If scope is not one of the Scope literals.
+    """
+    if scope not in _SCOPE_VALUES:
+        raise ValueError(f"Unknown scope {scope!r}; expected one of {_SCOPE_VALUES}")
+    return scope  # type: ignore[return-value]

--- a/src/oda_data/clean_data/common.py
+++ b/src/oda_data/clean_data/common.py
@@ -86,7 +86,7 @@ def clean_raw_df(df: pd.DataFrame) -> pd.DataFrame:
         pd.DataFrame: The cleaned dataframe.
     """
 
-    df = df.rename(columns=lambda c: clean_column_name(c))
+    df = df.rename(columns=clean_column_name)
 
     if "amount" in df.columns:
         df["amount"] = pd.to_numeric(df["amount"], errors="coerce").astype(

--- a/src/oda_data/config.py
+++ b/src/oda_data/config.py
@@ -1,6 +1,19 @@
 from pathlib import Path
 
 
+class _CacheRootDescriptor:
+    """Descriptor that delegates to oda_data_cache_root() on every access.
+
+    Resolves lazily at call time to avoid import-time side effects and to
+    honour env-var / set_cache_root() overrides that may arrive after import.
+    """
+
+    def __get__(self, obj, objtype=None) -> Path:
+        from oda_data.cache.config import oda_data_cache_root
+
+        return oda_data_cache_root()
+
+
 class ODAPaths:
     """Class to store the paths to the data and output folders."""
 
@@ -15,3 +28,7 @@ class ODAPaths:
     sectors = indicators / "sectors"
     tests = project / "tests"
     test_files = tests / "files"
+
+    # Lazy cache-root: delegates to cache/config.py on every access so that
+    # env-var and set_cache_root() overrides are always honoured.
+    cache_root: Path = _CacheRootDescriptor()  # type: ignore[assignment]

--- a/src/oda_data/tools/cache.py
+++ b/src/oda_data/tools/cache.py
@@ -13,11 +13,14 @@ import contextlib
 import hashlib
 import json
 import os
+import socket
 import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
 import pandas as pd
@@ -29,6 +32,47 @@ from oda_data.tools.names.create_mapping import snake_to_pascal
 
 # ISO format for timestamps
 ISO_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+
+# Hostname cached at module load — used in tmp-file suffixes so NFS/multi-host
+# writes don't collide on the same PID.
+_HOSTNAME: str = socket.gethostname()
+
+# Major version of the installed oda_data package, used in query-cache filenames
+# to auto-invalidate on major upgrades.
+try:
+    _PACKAGE_MAJOR_VERSION: str = _pkg_version("oda_data").split(".")[0]
+except PackageNotFoundError:
+    _PACKAGE_MAJOR_VERSION = "0"
+
+# Sweep threshold: tmp files older than this are removed on manager __init__.
+_TMP_SWEEP_MAX_AGE_SECONDS: int = 86400  # 24 hours
+
+
+def _tmp_path(path: Path, suffix: str = "") -> Path:
+    """Return a sibling temp path tagged with hostname + pid (+ optional suffix).
+
+    The hostname segment guards NFS / shared-volume scenarios where two hosts
+    can share a PID; the suffix allows multiple concurrent temp files in the
+    same atomic-write sequence (e.g. ``"retry"``, ``"nocache"``).
+    """
+    tail = f"-{suffix}" if suffix else ""
+    return Path(f"{path}.tmp-{_HOSTNAME}-{os.getpid()}{tail}")
+
+
+def _sweep_old_tmp_files(base_dir: Path) -> None:
+    """Remove ``*.tmp-*`` files in *base_dir* older than 24 hours.
+
+    Cleans up orphan temp files left by SIGKILL or other abnormal terminations
+    on any host. Errors are swallowed — a stale temp file is not worth raising.
+    """
+    cutoff = time.time() - _TMP_SWEEP_MAX_AGE_SECONDS
+    for f in base_dir.glob("*.tmp-*"):
+        try:
+            if f.stat().st_mtime < cutoff:
+                f.unlink()
+                logger.debug(f"Swept stale tmp file: {f}")
+        except OSError:
+            pass
 
 
 def generate_param_hash(filters: list[tuple]) -> str:
@@ -163,6 +207,8 @@ class BulkCacheManager:
         self._lock = FileLock(self.lock_path, timeout=1200)  # 20 min timeout
         self.ttl_seconds = ttl_seconds
 
+        _sweep_old_tmp_files(self.base_dir)
+
     def _get_path(self, entry: BulkCacheEntry) -> Path:
         """Get file path for a cache entry."""
         return self.base_dir / f"{entry.key}.parquet"
@@ -178,9 +224,9 @@ class BulkCacheManager:
             logger.warning(f"Failed to load manifest: {e}. Creating new manifest.")
             return {}
 
-    def _save_manifest(self, manifest: dict):
+    def _save_manifest(self, manifest: dict) -> None:
         """Save manifest to disk (atomic write)."""
-        tmp_path = Path(f"{self.manifest_path}.tmp-{os.getpid()}")
+        tmp_path = _tmp_path(self.manifest_path)
         try:
             with open(tmp_path, "w") as f:
                 json.dump(manifest, f, indent=2)
@@ -207,9 +253,21 @@ class BulkCacheManager:
     def ensure(self, entry: BulkCacheEntry, refresh: bool = False) -> Path:
         """Get cached bulk file or download if needed.
 
-        This method blocks with FileLock - if another thread/process is downloading
-        the same dataset, this call will wait for it to complete. This prevents
-        multiple concurrent downloads of the same data.
+        This method blocks with FileLock — if another thread/process is
+        downloading the same dataset, this call will wait for it to complete,
+        preventing concurrent duplicate downloads.
+
+        If the fetcher raises ``BulkPayloadCorruptError`` (e.g. a truncated zip
+        on disk), the corrupt entry is cleared and the fetch is retried once.
+        On a second failure the exception is re-raised with an actionable
+        message naming the cache path and the recovery hint.
+
+        If the ``bulk`` scope is disabled via ``oda_data.cache.disable_cache``,
+        every call re-fetches: the FileLock still serializes concurrent callers
+        and the parquet is written atomically to the canonical path, but the
+        manifest is NOT updated — so any later read with bulk enabled sees no
+        record and re-fetches as well, preserving the "no trusted cache"
+        semantic.
 
         Args:
             entry: Cache entry descriptor
@@ -218,68 +276,135 @@ class BulkCacheManager:
         Returns:
             Path to cached parquet file
         """
+        from oda_data.cache.api import is_scope_enabled
+
         with self._lock:
-            path = self._get_path(entry)
-            manifest = self._load_manifest()
-            record = manifest.get(entry.key)
+            bulk_path = self._ensure_inner(
+                entry,
+                refresh=refresh,
+                skip_manifest=not is_scope_enabled("bulk"),
+            )
+        return bulk_path
 
-            # Check if we have a fresh cached version
-            if (
-                not refresh
-                and record
-                and path.exists()
-                and not self._is_stale(record, entry)
-            ):
-                logger.info(f"Using cached bulk data for {entry.key}")
-                return path
+    def _ensure_inner(
+        self,
+        entry: BulkCacheEntry,
+        *,
+        refresh: bool,
+        skip_manifest: bool = False,
+    ) -> Path:
+        """Core fetch logic; assumes ``self._lock`` is already held.
 
-            # Need to download - use atomic write pattern
-            logger.info(f"Downloading bulk data for {entry.key}")
-            tmp_path = Path(f"{path}.tmp-{os.getpid()}")
+        ``skip_manifest=True`` is the disabled-scope path: re-fetch every time,
+        write the canonical file atomically, but leave the manifest alone so the
+        next enabled read still sees no trusted record.
+        """
+        from oda_reader import BulkPayloadCorruptError
+
+        path = self._get_path(entry)
+        manifest = self._load_manifest()
+        record = manifest.get(entry.key)
+
+        # Check if we have a fresh cached version.
+        if (
+            not refresh
+            and record
+            and path.exists()
+            and not self._is_stale(record, entry)
+        ):
+            logger.info(f"Using cached bulk data for {entry.key}")
+            return path
+
+        # Need to download — use atomic write pattern.
+        logger.info(f"Downloading bulk data for {entry.key}")
+        tmp_path = _tmp_path(path, "nocache" if skip_manifest else "")
+        manifest_dirty = False
+        try:
             try:
                 entry.fetcher(tmp_path)
-                tmp_path.replace(path)  # Atomic on POSIX systems
+            except BulkPayloadCorruptError as exc:
+                # First corruption: clear the stale entry and retry once.
+                logger.warning(
+                    f"Corrupt bulk payload for {entry.key}: {exc}. "
+                    "Clearing cache and retrying once."
+                )
+                self._clear_locked(entry.key)
+                manifest_dirty = True
+                tmp_path.unlink(missing_ok=True)
+                tmp_path2 = _tmp_path(
+                    path, "nocache-retry" if skip_manifest else "retry"
+                )
+                try:
+                    entry.fetcher(tmp_path2)
+                    tmp_path2.replace(path)
+                except Exception as exc2:
+                    tmp_path2.unlink(missing_ok=True)
+                    raise RuntimeError(
+                        f"Bulk payload at {path} failed integrity validation after "
+                        "retry. Run oda_data.cache.clear('raw') to wipe the raw "
+                        "cache and try again."
+                    ) from exc2
+            else:
+                tmp_path.replace(path)  # Atomic on POSIX systems.
 
-                # Update manifest
-                file_size = path.stat().st_size / (1024 * 1024)  # MB
-                manifest[entry.key] = {
-                    "filename": path.name,
-                    "downloaded_at": datetime.now(UTC).isoformat(),
-                    "version": entry.version,
-                    "size_mb": round(file_size, 2),
-                }
-                self._save_manifest(manifest)
-
-                logger.info(f"Cached bulk data for {entry.key} ({file_size:.1f} MB)")
+            if skip_manifest:
+                # Disabled-scope path: leave the manifest alone so the next
+                # enabled read sees no trusted record and re-fetches.
+                logger.info(
+                    f"Bulk scope disabled — fetched {entry.key} without "
+                    "updating manifest"
+                )
                 return path
 
-            finally:
-                tmp_path.unlink(missing_ok=True)
+            # Update manifest. If _clear_locked ran, our local copy is stale —
+            # re-read so we don't resurrect cleared keys.
+            if manifest_dirty:
+                manifest = self._load_manifest()
+            file_size = path.stat().st_size / (1024 * 1024)  # MB
+            manifest[entry.key] = {
+                "filename": path.name,
+                "downloaded_at": datetime.now(UTC).isoformat(),
+                "version": entry.version,
+                "size_mb": round(file_size, 2),
+            }
+            self._save_manifest(manifest)
 
-    def clear(self, key: str | None = None):
+            logger.info(f"Cached bulk data for {entry.key} ({file_size:.1f} MB)")
+            return path
+
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    def _clear_locked(self, key: str | None = None) -> None:
+        """Remove cached entries — assumes ``self._lock`` is already held.
+
+        Args:
+            key: Specific entry to remove, or None to remove all.
+        """
+        manifest = self._load_manifest()
+
+        if key is None:
+            for record in manifest.values():
+                filepath = self.base_dir / record["filename"]
+                filepath.unlink(missing_ok=True)
+            manifest.clear()
+            logger.info("Cleared all bulk cache entries")
+        elif key in manifest:
+            filepath = self.base_dir / manifest[key]["filename"]
+            filepath.unlink(missing_ok=True)
+            del manifest[key]
+            logger.info(f"Cleared bulk cache entry: {key}")
+
+        self._save_manifest(manifest)
+
+    def clear(self, key: str | None = None) -> None:
         """Remove cached entries.
 
         Args:
-            key: Specific entry to remove, or None to remove all
+            key: Specific entry to remove, or None to remove all.
         """
         with self._lock:
-            manifest = self._load_manifest()
-
-            if key is None:
-                # Clear all
-                for record in manifest.values():
-                    filepath = self.base_dir / record["filename"]
-                    filepath.unlink(missing_ok=True)
-                manifest.clear()
-                logger.info("Cleared all bulk cache entries")
-            # Clear specific entry
-            elif key in manifest:
-                filepath = self.base_dir / manifest[key]["filename"]
-                filepath.unlink(missing_ok=True)
-                del manifest[key]
-                logger.info(f"Cleared bulk cache entry: {key}")
-
-            self._save_manifest(manifest)
+            self._clear_locked(key)
 
     def stats(self) -> dict:
         """Get cache statistics.
@@ -355,10 +480,13 @@ class QueryCacheManager:
 
     Storage structure:
         {base_dir}/query_cache/
-        ├── .query.lock                    # FileLock for writes
-        ├── CRSData-abc123.parquet
-        ├── DAC1Data-def456.parquet
+        ├── .query.lock                         # FileLock for writes
+        ├── CRSData-abc123-v2.parquet
+        ├── DAC1Data-def456-v2.parquet
         └── ...
+
+    The ``-v{major}`` suffix in filenames auto-invalidates cached results when
+    the oda_data major version changes.
 
     Args:
         base_dir: Root directory for cache storage
@@ -373,9 +501,18 @@ class QueryCacheManager:
         self._lock = FileLock(self.lock_path, timeout=60)
         self.ttl_seconds = ttl_seconds
 
+        _sweep_old_tmp_files(self.base_dir)
+
     def get_file_path(self, dataset_name: str, param_hash: str) -> Path:
-        """Get file path for a cached query result."""
-        return self.base_dir / f"{dataset_name}-{param_hash}.parquet"
+        """Get file path for a cached query result.
+
+        Filename pattern: ``{dataset_name}-{param_hash}-v{major}.parquet``.
+        The ``-v{major}`` segment ensures cross-version isolation.
+        """
+        return (
+            self.base_dir
+            / f"{dataset_name}-{param_hash}-v{_PACKAGE_MAJOR_VERSION}.parquet"
+        )
 
     def _is_expired(self, path: Path) -> bool:
         """Check if a cached file has expired based on mtime."""
@@ -397,6 +534,9 @@ class QueryCacheManager:
         No lock needed - files are immutable after write. If file doesn't exist
         or is expired, returns None.
 
+        If the ``query`` scope is disabled via ``oda_data.cache.disable_cache``,
+        always returns None (forces re-compute).
+
         Args:
             dataset_name: Name of the dataset class
             param_hash: Hash of query parameters
@@ -406,6 +546,11 @@ class QueryCacheManager:
         Returns:
             DataFrame if cached and fresh, None otherwise
         """
+        from oda_data.cache.api import is_scope_enabled
+
+        if not is_scope_enabled("query"):
+            return None
+
         path = self.get_file_path(dataset_name, param_hash)
 
         # Handle MultiSystemData special case (PascalCase columns)
@@ -440,20 +585,28 @@ class QueryCacheManager:
                 path.unlink()
             return None
 
-    def save(self, dataset_name: str, param_hash: str, df: pd.DataFrame):
+    def save(self, dataset_name: str, param_hash: str, df: pd.DataFrame) -> None:
         """Save DataFrame to query cache.
 
         Uses FileLock + atomic write (temp file then rename) to prevent
         corruption from concurrent writes.
+
+        If the ``query`` scope is disabled via ``oda_data.cache.disable_cache``,
+        this is a no-op.
 
         Args:
             dataset_name: Name of the dataset class
             param_hash: Hash of query parameters
             df: DataFrame to cache
         """
+        from oda_data.cache.api import is_scope_enabled
+
+        if not is_scope_enabled("query"):
+            return
+
         with self._lock:
             path = self.get_file_path(dataset_name, param_hash)
-            tmp_path = Path(f"{path}.tmp-{os.getpid()}")
+            tmp_path = _tmp_path(path)
             try:
                 df.to_parquet(tmp_path)
                 tmp_path.replace(path)  # Atomic
@@ -462,7 +615,7 @@ class QueryCacheManager:
             finally:
                 tmp_path.unlink(missing_ok=True)
 
-    def clear(self):
+    def clear(self) -> None:
         """Remove all cached query results."""
         with self._lock:
             count = 0
@@ -474,7 +627,7 @@ class QueryCacheManager:
                     logger.warning(f"Failed to delete {file}: {e}")
             logger.info(f"Cleared {count} query cache entries")
 
-    def cleanup_expired(self):
+    def cleanup_expired(self) -> None:
         """Remove expired cache files (no lock - best effort)."""
         count = 0
         for file in self.base_dir.glob("*.parquet"):
@@ -513,6 +666,7 @@ def create_crs_bulk_fetcher() -> Callable[[Path], None]:
     """
     from oda_reader import bulk_download_crs
 
+    from oda_data.cache.api import is_scope_enabled
     from oda_data.clean_data.common import clean_parquet_file_in_batches
 
     def fetcher(target_path: Path):
@@ -523,11 +677,16 @@ def create_crs_bulk_fetcher() -> Callable[[Path], None]:
             download_dir = tmpdir / "crs_download"
 
             try:
-                # Download from oda_reader (creates directory with parquet files)
+                # Download from oda_reader (creates directory with parquet files).
+                # Honour cache.disable_cache("raw"): the per-call use_raw_cache
+                # flag is the only way to bypass oda_reader's bulk_files cache.
                 logger.info(
                     "Starting CRS bulk download (this may take several minutes)"
                 )
-                bulk_download_crs(save_to_path=download_dir)
+                bulk_download_crs(
+                    save_to_path=download_dir,
+                    use_raw_cache=is_scope_enabled("raw"),
+                )
 
                 # Find parquet files in the download directory
                 parquet_files = list(download_dir.glob("*.parquet"))
@@ -581,6 +740,7 @@ def create_multisystem_bulk_fetcher() -> Callable[[Path], None]:
     """
     from oda_reader import bulk_download_multisystem
 
+    from oda_data.cache.api import is_scope_enabled
     from oda_data.clean_data.common import clean_parquet_file_in_batches
 
     def fetcher(target_path: Path):
@@ -591,11 +751,15 @@ def create_multisystem_bulk_fetcher() -> Callable[[Path], None]:
             download_dir = tmpdir / "multisystem_download"
 
             try:
-                # Download from oda_reader (creates directory with parquet files)
+                # Download from oda_reader (creates directory with parquet files).
+                # Honour cache.disable_cache("raw") via the per-call flag.
                 logger.info(
                     "Starting MultiSystem bulk download (this may take several minutes)"
                 )
-                bulk_download_multisystem(save_to_path=download_dir)
+                bulk_download_multisystem(
+                    save_to_path=download_dir,
+                    use_raw_cache=is_scope_enabled("raw"),
+                )
 
                 # Find parquet files in the download directory
                 parquet_files = list(download_dir.glob("*.parquet"))

--- a/tests/cache/conftest.py
+++ b/tests/cache/conftest.py
@@ -1,0 +1,153 @@
+"""Shared fixtures for oda_data cache tests."""
+
+import io
+import os
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+@pytest.fixture()
+def tmp_cache_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Temporary cache root isolated from the real cache.
+
+    Sets ODA_DATA_CACHE_DIR to a subdirectory of tmp_path so tests never
+    touch the user's real platformdirs cache. The env var is restored on
+    teardown by monkeypatch automatically.
+
+    If slice (b) has landed, also calls ``set_cache_root`` so the module-level
+    override is consistent with the env var.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture.
+        tmp_path: pytest temporary directory.
+
+    Yields:
+        Path: Temporary cache root directory.
+    """
+    cache_dir = (tmp_path / "cache").resolve()
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("ODA_DATA_CACHE_DIR", str(cache_dir))
+
+    # Best-effort: apply the programmatic override too, but don't fail if the
+    # cache subpackage (slice (b)) has not landed yet.
+    try:
+        from oda_data.cache.config import set_cache_root
+
+        set_cache_root(cache_dir)
+    except ImportError:
+        pass
+
+    yield cache_dir
+
+
+def _make_valid_zip(target: Path) -> None:
+    """Write a ~1 KB valid zip containing one parquet-like entry."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("data.parquet", b"PAR1" + b"\x00" * 1000)
+    target.write_bytes(buf.getvalue())
+
+
+def _make_valid_parquet(target: Path) -> None:
+    """Write a minimal parquet file to *target*."""
+    df = pd.DataFrame({"year": [2022], "value": [1.0]})
+    df.to_parquet(target, engine="pyarrow")
+
+
+@pytest.fixture()
+def valid_tiny_zip(tmp_path: Path) -> Path:
+    """Path to a ~1 KB valid zip file with one parquet-like member.
+
+    Args:
+        tmp_path: pytest temporary directory.
+
+    Returns:
+        Path: Path to the valid zip file.
+    """
+    path = tmp_path / "valid.zip"
+    _make_valid_zip(path)
+    return path
+
+
+@pytest.fixture()
+def corrupt_zip_file(tmp_path: Path) -> Path:
+    """Path to a non-zip 1 KB file for corruption-recovery tests.
+
+    Args:
+        tmp_path: pytest temporary directory.
+
+    Returns:
+        Path: Path to the corrupt (non-zip) file.
+    """
+    path = tmp_path / "corrupt.zip"
+    path.write_bytes(b"NOT A ZIP" + b"\xff" * 1000)
+    return path
+
+
+@pytest.fixture()
+def monkeypatched_fetcher():
+    """Factory returning a callable that writes a 1 KB valid zip.
+
+    The returned callable matches the ``fetcher(target_path: Path)``
+    signature used by ``BulkCacheManager`` entries.
+
+    Returns:
+        Callable[[Path], None]: Fake fetcher writing a valid zip.
+    """
+
+    def _fetcher(target_path: Path) -> None:
+        _make_valid_zip(target_path)
+
+    return _fetcher
+
+
+@pytest.fixture()
+def populated_bulk_cache(tmp_cache_root: Path) -> Path:
+    """Cache root pre-populated with one bulk parquet entry.
+
+    Creates the directory layout expected by ``BulkCacheManager`` and
+    places a minimal parquet file so cache-hit paths can be exercised
+    without a real download.
+
+    Args:
+        tmp_cache_root: Fixture providing the temporary cache root.
+
+    Returns:
+        Path: Path to the bulk cache directory containing the seeded entry.
+    """
+    bulk_dir = tmp_cache_root / "oda-data" / "bulk_cache"
+    bulk_dir.mkdir(parents=True, exist_ok=True)
+    entry = bulk_dir / "CRSData_bulk.parquet"
+    _make_valid_parquet(entry)
+    return bulk_dir
+
+
+@pytest.fixture()
+def populated_query_cache(tmp_cache_root: Path) -> Path:
+    """Cache root pre-populated with one query parquet entry.
+
+    Creates the directory layout expected by ``QueryCacheManager`` and
+    places a minimal parquet file so query-cache-hit paths can be
+    exercised without a real download.
+
+    Args:
+        tmp_cache_root: Fixture providing the temporary cache root.
+
+    Returns:
+        Path: Path to the query cache directory containing the seeded entry.
+    """
+    query_dir = tmp_cache_root / "oda-data" / "query_cache"
+    query_dir.mkdir(parents=True, exist_ok=True)
+    entry = query_dir / "CRSData-abc123-v2.parquet"
+    _make_valid_parquet(entry)
+    return query_dir
+
+
+@pytest.fixture()
+def skip_if_no_network() -> None:
+    """Skip the current test when RUN_NETWORK_TESTS is not set to '1'."""
+    if os.environ.get("RUN_NETWORK_TESTS") != "1":
+        pytest.skip("set RUN_NETWORK_TESTS=1 to run network tests")

--- a/tests/cache/test_cache_api.py
+++ b/tests/cache/test_cache_api.py
@@ -1,0 +1,686 @@
+"""Unit tests for the oda_data.cache public API.
+
+Each test exercises one specific behaviour of a public cache function.
+The tmp_cache_root fixture (from conftest.py) ensures tests never touch
+the real user cache.
+"""
+
+from __future__ import annotations
+
+import logging
+import multiprocessing as mp
+import os
+import re
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+# Guard: slice (b) must land before these tests can run.
+pytest.importorskip(
+    "oda_data.cache",
+    reason="requires slice (b): oda_data.cache not yet available",
+)
+
+from oda_data import cache
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_parquet(path: Path) -> None:
+    """Write a minimal parquet file to *path*."""
+    df = pd.DataFrame({"year": [2022], "value": [1.0]})
+    df.to_parquet(path, engine="pyarrow")
+
+
+def _hold_lock(
+    lock_path: str,
+    hold_event: mp.synchronize.Event,
+    release_event: mp.synchronize.Event,
+) -> None:
+    """Acquire FileLock at *lock_path*, signal *hold_event*, wait for *release_event*.
+
+    Must be module-level so it is picklable by the ``spawn`` multiprocessing
+    context used in the contention test.
+    """
+    from filelock import FileLock
+
+    with FileLock(lock_path):
+        hold_event.set()
+        release_event.wait(timeout=10)
+
+
+# ---------------------------------------------------------------------------
+# cache.path
+# ---------------------------------------------------------------------------
+
+
+def test_path_default_returns_root(tmp_cache_root: Path) -> None:
+    """cache.path() with no args returns the cache root (scope='all')."""
+    result = cache.path()
+    assert result == tmp_cache_root
+
+
+def test_path_per_scope_returns_subdir(tmp_cache_root: Path) -> None:
+    """cache.path(scope) returns a subdirectory for each non-'all' scope."""
+    bulk = cache.path("bulk")
+    assert bulk == tmp_cache_root / "oda-data" / "bulk_cache"
+
+    query = cache.path("query")
+    assert query == tmp_cache_root / "oda-data" / "query_cache"
+
+    http = cache.path("http")
+    assert http == tmp_cache_root / "oda-reader" / "http_cache"
+
+    raw = cache.path("raw")
+    assert raw == tmp_cache_root / "oda-reader" / "bulk_files"
+
+
+def test_path_rejects_unknown_scope(tmp_cache_root: Path) -> None:
+    """cache.path('nonsense') raises ValueError."""
+    with pytest.raises(ValueError, match="nonsense"):
+        cache.path("nonsense")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# cache.entries
+# ---------------------------------------------------------------------------
+
+
+def test_entries_returns_records_per_scope(
+    populated_bulk_cache: Path, tmp_cache_root: Path
+) -> None:
+    """cache.entries() returns a four-key dict, one list per scope."""
+    result = cache.entries()
+    # Must have exactly the four concrete scopes (not "all").
+    assert set(result.keys()) == {"bulk", "query", "http", "raw"}
+    # populated_bulk_cache fixture wrote one parquet file in bulk.
+    assert len(result["bulk"]) >= 1
+    # Spot-check the CacheRecord fields.
+    record = result["bulk"][0]
+    assert record.scope == "bulk"
+    assert record.size_bytes > 0
+    assert record.age_days >= 0
+
+
+def test_entries_does_not_shadow_builtin_list(tmp_cache_root: Path) -> None:
+    """Calling cache.entries() does not break list(...)."""
+    cache.entries()
+    # If 'entries' shadowed the builtin 'list', this would raise NameError.
+    assert list(range(3)) == [0, 1, 2]
+
+
+# ---------------------------------------------------------------------------
+# cache.clear
+# ---------------------------------------------------------------------------
+
+
+def test_clear_blocking_clears_all(tmp_cache_root: Path) -> None:
+    """cache.clear('all') empties every scope."""
+    bulk_dir = tmp_cache_root / "oda-data" / "bulk_cache"
+    bulk_dir.mkdir(parents=True, exist_ok=True)
+    _write_parquet(bulk_dir / "CRSData_bulk.parquet")
+
+    result = cache.clear("all")
+    assert set(result.keys()) == {"bulk", "query", "http", "raw"}
+    # bulk had one file → should return 1 (or possibly 2 if manifest existed).
+    assert result["bulk"] is not None and result["bulk"] >= 1
+    assert not list(bulk_dir.glob("*.parquet"))
+
+
+def test_clear_returns_int_per_scope(tmp_cache_root: Path) -> None:
+    """cache.clear('bulk') returns {'bulk': N} where N is files deleted."""
+    bulk_dir = tmp_cache_root / "oda-data" / "bulk_cache"
+    bulk_dir.mkdir(parents=True, exist_ok=True)
+    for name in ("A_bulk.parquet", "B_bulk.parquet", "C_bulk.parquet"):
+        _write_parquet(bulk_dir / name)
+
+    result = cache.clear("bulk")
+    assert set(result.keys()) == {"bulk"}
+    assert isinstance(result["bulk"], int)
+    assert result["bulk"] == 3
+
+
+def test_clear_non_blocking_returns_none_under_contention(
+    tmp_cache_root: Path,
+) -> None:
+    """cache.clear(blocking=False) returns None for the contended scope."""
+    ctx = mp.get_context("spawn")
+    hold_event = ctx.Event()
+    release_event = ctx.Event()
+
+    # BulkCacheManager uses this lock path.
+    lock_path = tmp_cache_root / "oda-data" / "bulk_cache" / ".cache.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.touch()
+
+    holder = ctx.Process(
+        target=_hold_lock,
+        args=(str(lock_path), hold_event, release_event),
+    )
+    holder.start()
+    try:
+        assert hold_event.wait(timeout=5), "Holder process never acquired the lock"
+        result = cache.clear("bulk", blocking=False)
+        assert result == {"bulk": None}, f"Expected {{'bulk': None}}, got {result}"
+    finally:
+        release_event.set()
+        holder.join(timeout=5)
+
+
+def test_clear_rejects_unknown_scope(tmp_cache_root: Path) -> None:
+    """cache.clear('nonsense') raises ValueError."""
+    with pytest.raises(ValueError, match="nonsense"):
+        cache.clear("nonsense")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# cache.size
+# ---------------------------------------------------------------------------
+
+
+def test_size_returns_int_bytes(tmp_cache_root: Path) -> None:
+    """cache.size()['bulk'] equals the on-disk byte count."""
+    bulk_dir = tmp_cache_root / "oda-data" / "bulk_cache"
+    bulk_dir.mkdir(parents=True, exist_ok=True)
+    sentinel = bulk_dir / "CRSData_bulk.parquet"
+    sentinel.write_bytes(b"\x00" * 1024)
+
+    result = cache.size()
+    assert set(result.keys()) == {"bulk", "query", "http", "raw"}
+    assert isinstance(result["bulk"], int)
+    assert result["bulk"] == 1024
+
+
+def test_size_warns_above_5gb(
+    tmp_cache_root: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """cache.size() logs one WARNING when total cache exceeds 5 GB."""
+    import oda_data.cache.api as _api
+
+    # The "oda_data" logger has propagate=False, so caplog's root handler doesn't
+    # see records. Attach caplog.handler directly to it for the test.
+    _od_logger = logging.getLogger("oda_data")
+    _od_logger.addHandler(caplog.handler)
+
+    # Reset and restore the module-level gate so other tests in the same process
+    # are not affected by the flag being True after this test runs.
+    original = _api._WARNED_STALE_5GB
+    _api._WARNED_STALE_5GB = False
+    try:
+        # Use a sparse file (no real disk space consumed on APFS / ext4) to push
+        # the stale total over the 5 GB threshold.
+        parent = tmp_cache_root.parent
+        stale_root = parent / "stale-version"
+        stale_root.mkdir(parents=True, exist_ok=True)
+        stale_file = stale_root / "big.bin"
+        stale_file.touch()
+        os.truncate(stale_file, 6 * 2**30)  # 6 GB sparse
+
+        with caplog.at_level(logging.WARNING):
+            cache.size()
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) >= 1
+        assert any('clear(scope="raw")' in r.message for r in warnings)
+
+        # Second call must NOT emit another warning (process-level gate).
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            cache.size()
+        second_warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "5 GB" in r.message
+        ]
+        assert len(second_warnings) == 0, "Should not warn twice in the same process"
+    finally:
+        _api._WARNED_STALE_5GB = original
+        _od_logger.removeHandler(caplog.handler)
+
+
+def test_size_rejects_unknown_scope_via_path(tmp_cache_root: Path) -> None:
+    """Calling cache.path with an invalid scope propagates a ValueError."""
+    with pytest.raises(ValueError, match="nonsense"):
+        cache.path("nonsense")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# cache.invalidate
+# ---------------------------------------------------------------------------
+
+
+def test_invalidate_known_class_clears_one_entry(
+    populated_bulk_cache: Path,
+    tmp_cache_root: Path,
+) -> None:
+    """cache.invalidate(CRSData) removes only the CRSData_bulk entry."""
+    from oda_data import (
+        CRSData,
+        DAC1Data,  # noqa: F401 — imported to register the subclass
+    )
+
+    bulk_dir = populated_bulk_cache  # already has CRSData_bulk.parquet
+    # Also add a second dataset entry so we can verify only one is removed.
+    _write_parquet(bulk_dir / "DAC1Data_bulk.parquet")
+
+    cache.invalidate(CRSData)
+
+    assert not (bulk_dir / "CRSData_bulk.parquet").exists()
+    assert (bulk_dir / "DAC1Data_bulk.parquet").exists()
+
+
+def test_invalidate_known_string_clears_one_entry(
+    populated_bulk_cache: Path,
+    tmp_cache_root: Path,
+) -> None:
+    """cache.invalidate('CRSData') removes only the CRSData_bulk entry."""
+    from oda_data import DAC1Data  # noqa: F401 — imported to register subclass
+
+    bulk_dir = populated_bulk_cache
+    _write_parquet(bulk_dir / "DAC1Data_bulk.parquet")
+
+    cache.invalidate("CRSData")
+
+    assert not (bulk_dir / "CRSData_bulk.parquet").exists()
+    assert (bulk_dir / "DAC1Data_bulk.parquet").exists()
+
+
+def test_invalidate_lowercase_string_raises(tmp_cache_root: Path) -> None:
+    """cache.invalidate('crsdata') raises ValueError; message lists 'CRSData'."""
+    with pytest.raises(ValueError) as exc_info:
+        cache.invalidate("crsdata")
+    assert "CRSData" in str(exc_info.value)
+
+
+def test_invalidate_unknown_string_raises_valueerror(tmp_cache_root: Path) -> None:
+    """cache.invalidate('Nonsense') raises ValueError."""
+    with pytest.raises(ValueError, match="Nonsense"):
+        cache.invalidate("Nonsense")
+
+
+# ---------------------------------------------------------------------------
+# cache.enable_cache / cache.disable_cache
+# ---------------------------------------------------------------------------
+
+
+def test_enable_disable_cache_per_scope(tmp_cache_root: Path) -> None:
+    """disable_cache('bulk') prevents caching; enable_cache restores it."""
+    from oda_data.cache.api import is_scope_enabled
+
+    # Disable bulk scope and verify the flag is set.
+    cache.disable_cache("bulk")
+    assert not is_scope_enabled("bulk")
+
+    # Re-enable and confirm the flag is restored.
+    cache.enable_cache("bulk")
+    assert is_scope_enabled("bulk")
+
+    # Invalid scope should raise ValueError on both.
+    with pytest.raises(ValueError, match="nonsense"):
+        cache.disable_cache("nonsense")  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="nonsense"):
+        cache.enable_cache("nonsense")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# DACSource.read(refresh=True)
+# ---------------------------------------------------------------------------
+
+
+def test_read_refresh_true_bypasses_cache(tmp_cache_root: Path) -> None:
+    """BulkCacheManager.ensure(refresh=True) re-fetches even when cache is warm."""
+    from oda_data.tools.cache import BulkCacheEntry, BulkCacheManager
+
+    call_count = {"n": 0}
+
+    def _sentinel_fetcher(target_path: Path) -> None:
+        call_count["n"] += 1
+        pd.DataFrame({"year": [2022], "value": [float(call_count["n"])]}).to_parquet(
+            target_path, engine="pyarrow"
+        )
+
+    mgr = BulkCacheManager(tmp_cache_root / "oda-data")
+    entry = BulkCacheEntry(key="CRSData_bulk", fetcher=_sentinel_fetcher, ttl_days=30)
+
+    # First ensure — populates the cache (1 fetch).
+    mgr.ensure(entry, refresh=False)
+    assert call_count["n"] == 1
+
+    # Second ensure without refresh — should be a cache hit (no extra fetch).
+    mgr.ensure(entry, refresh=False)
+    assert call_count["n"] == 1
+
+    # Third ensure with refresh=True — must trigger a re-fetch even though cached.
+    mgr.ensure(entry, refresh=True)
+    assert call_count["n"] == 2, "refresh=True must trigger a re-fetch"
+
+
+# ---------------------------------------------------------------------------
+# Lock reentrancy
+# ---------------------------------------------------------------------------
+
+
+def test_clear_lock_reentrancy_via_clear_locked(tmp_cache_root: Path) -> None:
+    """Retry path in ensure() uses _clear_locked and does not deadlock."""
+    from oda_data.tools.cache import BulkCacheEntry, BulkCacheManager
+
+    bulk_dir = tmp_cache_root / "oda-data"
+    mgr = BulkCacheManager(bulk_dir)
+
+    fetch_count = {"n": 0}
+
+    def _corrupt_then_valid(target_path: Path) -> None:
+        from oda_reader import BulkPayloadCorruptError
+
+        fetch_count["n"] += 1
+        if fetch_count["n"] == 1:
+            # First call: write a corrupt payload and raise.
+            target_path.write_bytes(b"NOT A PARQUET")
+            raise BulkPayloadCorruptError(target_path, reason="test corruption")
+        # Second call: write a real parquet.
+        df = pd.DataFrame({"year": [2022], "value": [1.0]})
+        df.to_parquet(target_path, engine="pyarrow")
+
+    entry = BulkCacheEntry(
+        key="CRSData_bulk",
+        fetcher=_corrupt_then_valid,
+        ttl_days=30,
+    )
+
+    # Should not deadlock; BulkPayloadCorruptError triggers _clear_locked (reentrancy).
+    result_path = mgr.ensure(entry)
+    assert result_path.exists()
+    assert fetch_count["n"] == 2, "Expected exactly one retry after corruption"
+
+
+# ---------------------------------------------------------------------------
+# Level-1 holdovers (absorbed from slice (f))
+# ---------------------------------------------------------------------------
+
+
+def test_query_cache_filename_includes_major_version(tmp_cache_root: Path) -> None:
+    """Query-cache filename matches r'.+-v\\d+\\.parquet$'."""
+    from oda_data.tools.cache import QueryCacheManager
+
+    mgr = QueryCacheManager(tmp_cache_root / "oda-data")
+    p = mgr.get_file_path("CRSData", "abc123")
+    assert re.search(r".+-v\d+\.parquet$", p.name), (
+        f"Query-cache filename {p.name!r} does not include major version segment"
+    )
+
+
+def test_startup_sweep_removes_old_tmp_files(tmp_cache_root: Path) -> None:
+    """BulkCacheManager.__init__ removes *.tmp-* files older than 24 h."""
+    from oda_data.tools.cache import BulkCacheManager
+
+    bulk_dir = tmp_cache_root / "oda-data" / "bulk_cache"
+    bulk_dir.mkdir(parents=True, exist_ok=True)
+
+    stale_tmp = bulk_dir / "CRSData_bulk.parquet.tmp-host-1234"
+    stale_tmp.write_bytes(b"\x00" * 64)
+    # Back-date the mtime by 25 hours so it appears stale.
+    stale_mtime = time.time() - 25 * 3600
+    os.utime(stale_tmp, (stale_mtime, stale_mtime))
+
+    # Constructing BulkCacheManager triggers _sweep_old_tmp_files().
+    BulkCacheManager(tmp_cache_root / "oda-data")
+
+    assert not stale_tmp.exists(), (
+        "Stale tmp file should have been removed by startup sweep"
+    )
+
+
+def test_startup_sweep_keeps_recent_tmp_files(tmp_cache_root: Path) -> None:
+    """BulkCacheManager.__init__ leaves *.tmp-* files younger than 24 h untouched."""
+    from oda_data.tools.cache import BulkCacheManager
+
+    bulk_dir = tmp_cache_root / "oda-data" / "bulk_cache"
+    bulk_dir.mkdir(parents=True, exist_ok=True)
+
+    recent_tmp = bulk_dir / "CRSData_bulk.parquet.tmp-host-5678"
+    recent_tmp.write_bytes(b"\x00" * 64)
+    # mtime is 1 hour ago — should survive the sweep.
+    recent_mtime = time.time() - 3600
+    os.utime(recent_tmp, (recent_mtime, recent_mtime))
+
+    BulkCacheManager(tmp_cache_root / "oda-data")
+
+    assert recent_tmp.exists(), "Recent tmp file should NOT be removed by startup sweep"
+
+
+# ---------------------------------------------------------------------------
+# F-1: _clear_oda_reader_scope always returns int, never None
+# ---------------------------------------------------------------------------
+
+
+def test_clear_oda_reader_scope_returns_int_not_none(tmp_cache_root: Path) -> None:
+    """cache.clear('http', blocking=False) returns an int, never None."""
+    http_dir = tmp_cache_root / "oda-reader" / "http_cache"
+    http_dir.mkdir(parents=True, exist_ok=True)
+    (http_dir / "dummy.bin").write_bytes(b"\x00" * 64)
+
+    result = cache.clear("http", blocking=False)
+
+    assert isinstance(result["http"], int), (
+        f"Expected int for http scope, got {result['http']!r}"
+    )
+    assert result["http"] == 1
+
+
+# ---------------------------------------------------------------------------
+# F-4: enable/disable coupling between http and raw scopes
+# ---------------------------------------------------------------------------
+
+
+def test_disable_http_couples_raw(tmp_cache_root: Path) -> None:
+    """disable_cache('http') also disables the 'raw' scope."""
+    from oda_data.cache.api import is_scope_enabled
+
+    cache.disable_cache("http")
+    assert not is_scope_enabled("http"), "http should be disabled"
+    assert not is_scope_enabled("raw"), "raw should be disabled when http is toggled"
+
+    cache.enable_cache("http")
+    assert is_scope_enabled("http"), "http should be re-enabled"
+    assert is_scope_enabled("raw"), "raw should be re-enabled when http is toggled"
+
+
+def test_disable_raw_couples_http(tmp_cache_root: Path) -> None:
+    """disable_cache('raw') also disables the 'http' scope."""
+    from oda_data.cache.api import is_scope_enabled
+
+    cache.disable_cache("raw")
+    assert not is_scope_enabled("raw"), "raw should be disabled"
+    assert not is_scope_enabled("http"), "http should be disabled when raw is toggled"
+
+    cache.enable_cache("raw")
+    assert is_scope_enabled("raw"), "raw should be re-enabled"
+    assert is_scope_enabled("http"), "http should be re-enabled when raw is toggled"
+
+
+# ---------------------------------------------------------------------------
+# F-6: _invalidate_query_entries acquires .query.lock
+# ---------------------------------------------------------------------------
+
+
+def test_invalidate_query_acquires_lock(tmp_cache_root: Path) -> None:
+    """cache.invalidate blocks while .query.lock is held by another process."""
+    import threading
+
+    from oda_data import CRSData  # noqa: F401 — register subclass
+
+    query_dir = tmp_cache_root / "oda-data" / "query_cache"
+    query_dir.mkdir(parents=True, exist_ok=True)
+
+    ctx = mp.get_context("spawn")
+    hold_event = ctx.Event()
+    release_event = ctx.Event()
+
+    lock_path = query_dir / ".query.lock"
+    lock_path.touch()
+
+    holder = ctx.Process(
+        target=_hold_lock,
+        args=(str(lock_path), hold_event, release_event),
+    )
+    holder.start()
+
+    invalidate_error: list[BaseException] = []
+
+    def _run_invalidate() -> None:
+        try:
+            cache.invalidate("CRSData")
+        except Exception as exc:
+            invalidate_error.append(exc)
+
+    try:
+        assert hold_event.wait(timeout=5), "Holder process never acquired the lock"
+
+        t = threading.Thread(target=_run_invalidate, daemon=True)
+        t.start()
+        t.join(timeout=2.0)
+        assert t.is_alive(), (
+            "invalidate should have been blocked on .query.lock but it already finished"
+        )
+
+        release_event.set()
+        t.join(timeout=5.0)
+        assert not t.is_alive(), (
+            "invalidate should have finished after lock was released"
+        )
+    finally:
+        release_event.set()
+        holder.join(timeout=5)
+
+    if invalidate_error:
+        raise invalidate_error[0]
+
+
+# ---------------------------------------------------------------------------
+# F-7: _invalidate_bulk_entry reuses Source._shared_bulk_cache singleton
+# ---------------------------------------------------------------------------
+
+
+def test_invalidate_reuses_shared_bulk_cache_singleton(
+    tmp_cache_root: Path,
+) -> None:
+    """cache.invalidate uses Source._shared_bulk_cache when base_dir matches."""
+    from oda_data import CRSData
+    from oda_data.api.sources import Source
+    from oda_data.tools.cache import BulkCacheManager
+
+    # Prime the singleton by accessing the bulk_cache property.
+    _ = CRSData().bulk_cache
+    assert Source._shared_bulk_cache is not None, "Singleton should be set after access"
+
+    with patch.object(
+        BulkCacheManager,
+        "__init__",
+        autospec=True,
+        side_effect=BulkCacheManager.__init__,
+    ) as init_spy:
+        cache.invalidate("CRSData")
+
+    assert init_spy.call_count == 0, (
+        f"BulkCacheManager.__init__ was called {init_spy.call_count} time(s) — "
+        "expected 0 (singleton should have been reused)"
+    )
+
+
+def test_invalidate_constructs_when_no_singleton(
+    tmp_cache_root: Path,
+) -> None:
+    """cache.invalidate constructs a fresh BulkCacheManager when singleton is None."""
+    from oda_data import CRSData  # noqa: F401 — register subclass
+    from oda_data.api.sources import Source
+    from oda_data.tools.cache import BulkCacheManager
+
+    # Ensure no singleton is set.
+    Source._shared_bulk_cache = None
+
+    with patch.object(
+        BulkCacheManager,
+        "__init__",
+        autospec=True,
+        side_effect=BulkCacheManager.__init__,
+    ) as init_spy:
+        cache.invalidate("CRSData")
+
+    assert init_spy.call_count == 1, (
+        f"BulkCacheManager.__init__ was called {init_spy.call_count} time(s) — "
+        "expected exactly 1 (fallback construction)"
+    )
+
+
+def test_tmp_suffix_uses_host_and_pid(tmp_cache_root: Path) -> None:
+    """Temp files use .tmp-<hostname>-<pid> suffix."""
+    from oda_data.tools.cache import BulkCacheEntry, BulkCacheManager
+
+    bulk_dir = tmp_cache_root / "oda-data"
+
+    seen_paths: list[Path] = []
+
+    def _capturing_fetcher(target_path: Path) -> None:
+        seen_paths.append(target_path)
+        pd.DataFrame({"year": [2022], "value": [1.0]}).to_parquet(
+            target_path, engine="pyarrow"
+        )
+
+    fake_host = "alice"
+    fake_pid = 1234
+
+    with (
+        patch("oda_data.tools.cache._HOSTNAME", fake_host),
+        patch("os.getpid", return_value=fake_pid),
+    ):
+        mgr = BulkCacheManager(bulk_dir)
+        entry = BulkCacheEntry(
+            key="CRSData_bulk",
+            fetcher=_capturing_fetcher,
+            ttl_days=30,
+        )
+        mgr.ensure(entry)
+
+    assert seen_paths, "Fetcher was never called"
+    tmp_name = seen_paths[0].name
+    expected_suffix = f"tmp-{fake_host}-{fake_pid}"
+    assert expected_suffix in tmp_name, (
+        f"Tmp filename {tmp_name!r} should contain {expected_suffix!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# F-8: ODA_DATA_CACHE_DIR relative path is resolved to absolute
+# ---------------------------------------------------------------------------
+
+
+def test_env_var_relative_path_is_resolved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_resolve_cache_root resolves a relative ODA_DATA_CACHE_DIR to an absolute path.
+
+    Uses monkeypatch.chdir + monkeypatch.setenv so the test is self-contained.
+    Explicitly clears _cache_root_override so the env-var branch is reached
+    (defensive until Slice C autouse fixture is in place).
+    """
+    import oda_data.cache.config as cfg
+
+    # Explicit override reset — guards against state leakage from prior tests
+    # that called set_cache_root (via tmp_cache_root fixture).  Slice C's
+    # autouse fixture will make this redundant once it lands.
+    monkeypatch.setattr(cfg, "_cache_root_override", None)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("ODA_DATA_CACHE_DIR", "./relative_cache")
+
+    result = cache.path()
+    assert result == (tmp_path / "relative_cache").resolve(), (
+        f"Expected absolute resolved path, got {result!r}"
+    )

--- a/tests/cache/test_network_integration.py
+++ b/tests/cache/test_network_integration.py
@@ -1,0 +1,31 @@
+"""Network integration tests for oda_data bulk download.
+
+These tests require live network access and are skipped unless
+RUN_NETWORK_TESTS=1 is set in the environment.
+
+Run with:
+    RUN_NETWORK_TESTS=1 uv run pytest tests/cache/test_network_integration.py -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip(
+    "oda_data.cache",
+    reason="requires slice (b): oda_data.cache not yet available",
+)
+
+
+@pytest.mark.network
+def test_crs_bulk_download_returns_nonempty(
+    tmp_cache_root: Path, skip_if_no_network: None
+) -> None:
+    """CRSData.read(using_bulk_download=True) returns a non-empty DataFrame."""
+    from oda_data import CRSData
+
+    df = CRSData(years=[2022]).read(using_bulk_download=True)
+    assert df is not None
+    assert len(df) > 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ This module provides reusable fixtures for testing the oda-data package,
 including sample DataFrames, mock objects, and test utilities.
 """
 
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from pathlib import Path
 
 import pandas as pd
@@ -410,6 +410,55 @@ def assert_series_equal(
         check_dtype=check_dtype,
         rtol=rtol,
     )
+
+
+# ============================================================================
+# Cache Module Isolation
+# ============================================================================
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache_module_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[None, None, None]:
+    """Reset module-level cache flags before every test.
+
+    Guarantees test isolation for three mutable globals the cache
+    subsystem keeps:
+
+    - ``cache.config._AUTO_MIGRATED``
+    - ``cache.config._LAST_CHAINED_ROOT``
+    - ``cache.api._WARNED_STALE_5GB``
+
+    ``cache.config._cache_root_override`` is intentionally NOT reset here:
+    ``tmp_cache_root`` already manages it via ``set_cache_root`` +
+    monkeypatch. Resetting it here would race with that fixture's setup
+    (autouse fixtures + `tmp_cache_root` share the same ``monkeypatch``,
+    and resetting the override after `set_cache_root` would null out the
+    installed value mid-test).
+
+    Uses ``monkeypatch.setattr`` so resets are reverted automatically on
+    teardown — guards against tests that mutate the flags but forget to
+    restore them. Falls back to a no-op when ``oda_data.cache`` is not
+    importable (e.g. during early scaffolding), mirroring the
+    ``tmp_cache_root`` fixture's tolerance pattern.
+
+    MAINTAINER NOTE: Adding a new module-level mutable flag to
+    ``cache.config`` or ``cache.api`` requires updating this fixture
+    to reset it. Otherwise tests that mutate the flag will leak state to
+    subsequent tests in the same worker.
+    """
+    try:
+        import oda_data.cache.api as _api
+        import oda_data.cache.config as _cfg
+    except ImportError:
+        yield
+        return
+
+    monkeypatch.setattr(_cfg, "_AUTO_MIGRATED", False, raising=False)
+    monkeypatch.setattr(_cfg, "_LAST_CHAINED_ROOT", None, raising=False)
+    monkeypatch.setattr(_api, "_WARNED_STALE_5GB", False, raising=False)
+    yield
 
 
 # ============================================================================

--- a/tests/migration/conftest.py
+++ b/tests/migration/conftest.py
@@ -1,0 +1,96 @@
+"""Shared fixtures for oda_data migration tests."""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+
+@pytest.fixture()
+def tmp_old_layout(tmp_path: Path) -> Path:
+    """A pre-2.6 cache layout under tmp_path for migration tests.
+
+    Creates the CWD ``.raw_data`` directory structure that the migration
+    scanner expects to find, containing a minimal parquet file in each
+    sub-directory.
+
+    Args:
+        tmp_path: pytest temporary directory.
+
+    Returns:
+        Path: Root of the old layout (``tmp_path / ".raw_data"``).
+    """
+    old_root = tmp_path / ".raw_data"
+    # Build once; written into each sub-directory so migration has something to move.
+    seed_df = pd.DataFrame({"year": [2022], "value": [1.0]})
+    for sub in ("http_cache", "bulk_cache", "query_cache", "bulk_files"):
+        sub_dir = old_root / sub
+        sub_dir.mkdir(parents=True, exist_ok=True)
+        seed_df.to_parquet(sub_dir / "seed.parquet", engine="pyarrow")
+    return old_root
+
+
+@pytest.fixture()
+def synced_drive_marker_factory(tmp_path: Path):
+    """Factory that plants a synced-drive marker inside tmp_path.
+
+    Usage::
+
+        def test_dropbox(synced_drive_marker_factory):
+            old_root = synced_drive_marker_factory(".dropbox")
+            # old_root is now the simulated old cache dir whose ancestor
+            # contains the .dropbox marker.
+
+    Parametrize over the marker names from ``_is_synced_drive``'s
+    authoritative list:
+
+    - ``.dropbox``
+    - ``.dropbox.cache``
+    - ``com.apple.iCloud``
+    - a path segment named ``OneDrive``
+    - a path segment matching ``OneDrive - Personal``
+    - a path segment matching ``OneDrive - Some Tenant``
+
+    iCloud's ``~/Library/Mobile Documents/`` case is handled by path
+    rather than a file marker; use ``synced_drive_marker_factory("mobile_documents")``
+    to create a path under a synthetic ``Mobile Documents`` ancestor.
+
+    Args:
+        tmp_path: pytest temporary directory.
+
+    Returns:
+        Callable[[str], Path]: Factory(marker_name) -> old_cache_root.
+    """
+
+    def _factory(marker_name: str) -> Path:
+        """Plant *marker_name* as an ancestor of the returned old-cache root.
+
+        Args:
+            marker_name: One of the known marker names, or ``'mobile_documents'``
+                to simulate an iCloud path.
+
+        Returns:
+            Path: Old cache root with the marker already in place.
+        """
+        if marker_name == "mobile_documents":
+            # Simulate ~/Library/Mobile Documents/ by nesting under that name.
+            ancestor = tmp_path / "Library" / "Mobile Documents" / "app"
+        elif marker_name in (
+            "OneDrive",
+            "OneDrive - Personal",
+            "OneDrive - Some Tenant",
+        ):
+            # OneDrive is detected by path-segment name, not a file marker.
+            ancestor = tmp_path / marker_name / "data"
+        else:
+            # File-based markers (.dropbox, .dropbox.cache, com.apple.iCloud).
+            ancestor = tmp_path / "synced_parent"
+            ancestor.mkdir(parents=True, exist_ok=True)
+            (ancestor / marker_name).touch()
+
+        ancestor.mkdir(parents=True, exist_ok=True)
+        old_root = ancestor / "old_cache"
+        old_root.mkdir(parents=True, exist_ok=True)
+        return old_root
+
+    return _factory

--- a/tests/migration/test_migration_matrix.py
+++ b/tests/migration/test_migration_matrix.py
@@ -1,0 +1,413 @@
+"""Parametrized migration-matrix tests for oda_data.cache.migrate.
+
+The synced-drive marker list used here is the authoritative set from
+``_is_synced_drive``:
+
+- ``.dropbox``
+- ``.dropbox.cache``
+- ``com.apple.iCloud``
+- path under ``~/Library/Mobile Documents/`` (``mobile_documents``)
+- path segment exactly ``OneDrive``
+- path segment ``OneDrive - Personal``
+- path segment ``OneDrive - Some Tenant``
+"""
+
+import errno
+import logging
+import shutil
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from oda_data.cache._migrate import (
+    MigrationResult,
+    _is_cross_volume,
+    _migrate_tree,
+    migrate,
+)
+
+# ---------------------------------------------------------------------------
+# Authoritative synced-drive marker list — must match _is_synced_drive exactly.
+# Each tuple: (marker_name, setup_fn) where setup_fn(tmp_path) creates the
+# marker under tmp_path and returns the path that should be detected as synced.
+# ---------------------------------------------------------------------------
+
+_SYNCED_DRIVE_MARKERS = [
+    ".dropbox",
+    ".dropbox.cache",
+    "com.apple.iCloud",
+    "mobile_documents",
+    "OneDrive",
+    "OneDrive - Personal",
+    "OneDrive - Some Tenant",
+]
+
+
+def _make_old_tree(root: Path) -> None:
+    """Create a small fake old-cache tree under *root* (3 files, 128 B each)."""
+    for name in ("data/a.parquet", "data/b.parquet", "meta.json"):
+        f = root / name
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_bytes(b"x" * 128)
+
+
+# ---------------------------------------------------------------------------
+# Same-volume / cross-volume
+# ---------------------------------------------------------------------------
+
+
+def test_same_volume_uses_move(tmp_path: Path) -> None:
+    """Same-volume migration calls shutil.move (not copy2+unlink)."""
+    src = tmp_path / "old_cache"
+    dst = tmp_path / "new_cache"
+    _make_old_tree(src)
+
+    move_calls: list[tuple] = []
+    real_move = shutil.move
+
+    def spy_move(src_arg, dst_arg):
+        move_calls.append((src_arg, dst_arg))
+        return real_move(src_arg, dst_arg)
+
+    with patch("oda_data.cache._migrate.shutil.move", side_effect=spy_move):
+        result = _migrate_tree(src, dst, force=False, is_cross_volume=lambda *_: False)
+
+    assert result.status == "migrated"
+    assert len(move_calls) == 3
+    assert result.files_moved == 3
+    assert result.bytes_moved == 3 * 128
+
+
+def test_cross_volume_uses_copy2_and_unlink(tmp_path: Path) -> None:
+    """Cross-volume migration calls shutil.copy2 then unlink."""
+    src = tmp_path / "old_cache"
+    dst = tmp_path / "new_cache"
+    _make_old_tree(src)
+
+    copy2_calls: list[tuple] = []
+    unlink_calls: list[Path] = []
+    real_copy2 = shutil.copy2
+
+    def spy_copy2(src_arg, dst_arg):
+        copy2_calls.append((src_arg, dst_arg))
+        return real_copy2(src_arg, dst_arg)
+
+    original_unlink = Path.unlink
+
+    def spy_unlink(self, *, missing_ok=False):
+        if self.suffix in (".parquet", ".json"):
+            unlink_calls.append(self)
+        return original_unlink(self, missing_ok=missing_ok)
+
+    with (
+        patch("oda_data.cache._migrate.shutil.copy2", side_effect=spy_copy2),
+        patch.object(Path, "unlink", spy_unlink),
+    ):
+        result = _migrate_tree(src, dst, force=False, is_cross_volume=lambda *_: True)
+
+    assert result.status == "migrated"
+    assert len(copy2_calls) == 3
+    assert len(unlink_calls) == 3
+    assert result.files_moved == 3
+    assert result.bytes_moved == 3 * 128
+
+
+def test_is_cross_volume_unit(tmp_path: Path) -> None:
+    """_is_cross_volume returns False for two paths sharing the same tmp volume."""
+    a = tmp_path / "alpha"
+    a.mkdir()
+    b = tmp_path / "beta"
+    b.mkdir()
+    assert _is_cross_volume(a, b) is False
+
+
+# ---------------------------------------------------------------------------
+# Synced-drive: single .dropbox marker (explicit test)
+# ---------------------------------------------------------------------------
+
+
+def test_synced_drive_marker_dropbox_skips(tmp_path: Path) -> None:
+    """_migrate_tree returns skipped_synced_drive when .dropbox marker is present."""
+    (tmp_path / ".dropbox").touch()
+    src = tmp_path / "data"
+    dst = tmp_path / "new_cache"
+    _make_old_tree(src)
+
+    result = _migrate_tree(src, dst, force=False)
+
+    assert result.status == "skipped_synced_drive"
+    assert result.files_moved == 0
+    assert not (dst / "data" / "a.parquet").exists()
+
+
+# ---------------------------------------------------------------------------
+# Parametrized synced-drive matrix
+# ---------------------------------------------------------------------------
+
+
+def _setup_synced_marker(tmp_path: Path, marker_name: str) -> Path:
+    """Create the named synced-drive marker under *tmp_path* and return the src dir.
+
+    All callers also patch ``Path.home()`` to return *tmp_path* so the
+    ancestor walk stops at our tmp root instead of the real home directory.
+    """
+    if marker_name == "mobile_documents":
+        # iCloud Mobile Documents — path must be under ~/Library/Mobile Documents.
+        mobile_docs = tmp_path / "Library" / "Mobile Documents"
+        mobile_docs.mkdir(parents=True, exist_ok=True)
+        src = mobile_docs / "data"
+        src.mkdir(parents=True, exist_ok=True)
+        return src
+
+    if marker_name in (".dropbox", ".dropbox.cache", "com.apple.iCloud"):
+        (tmp_path / marker_name).touch()
+        src = tmp_path / "data"
+        src.mkdir(parents=True, exist_ok=True)
+        return src
+
+    if marker_name in ("OneDrive", "OneDrive - Personal", "OneDrive - Some Tenant"):
+        onedrive_dir = tmp_path / marker_name
+        onedrive_dir.mkdir(parents=True, exist_ok=True)
+        src = onedrive_dir / "data"
+        src.mkdir(parents=True, exist_ok=True)
+        return src
+
+    raise ValueError(f"Unknown marker fixture: {marker_name!r}")
+
+
+@pytest.mark.parametrize("marker_name", _SYNCED_DRIVE_MARKERS)
+def test_synced_drive_matrix(tmp_path: Path, marker_name: str) -> None:
+    """Each synced-drive marker triggers skipped_synced_drive status."""
+    src = _setup_synced_marker(tmp_path, marker_name)
+    _make_old_tree(src)
+    dst = tmp_path / "new_cache"
+
+    with patch("oda_data.cache._migrate.Path.home", return_value=tmp_path):
+        result = _migrate_tree(src, dst, force=False)
+
+    assert result.status == "skipped_synced_drive", (
+        f"Expected skipped_synced_drive for marker={marker_name!r}, "
+        f"got {result.status!r}: {result.message}"
+    )
+    assert result.files_moved == 0
+
+
+# ---------------------------------------------------------------------------
+# force=True bypasses synced-drive guard
+# ---------------------------------------------------------------------------
+
+
+def test_force_true_bypasses_synced_drive_guard(tmp_path: Path) -> None:
+    """migrate(force=True) migrates even when a synced-drive marker is present."""
+    (tmp_path / ".dropbox").touch()
+    src = tmp_path / "data"
+    dst = tmp_path / "new_cache"
+    _make_old_tree(src)
+
+    with patch("oda_data.cache._migrate.Path.home", return_value=tmp_path):
+        result = _migrate_tree(src, dst, force=True)
+
+    assert result.status == "migrated"
+    assert result.files_moved == 3
+
+
+# ---------------------------------------------------------------------------
+# Breadcrumb
+# ---------------------------------------------------------------------------
+
+
+def test_breadcrumb_written(tmp_path: Path) -> None:
+    """Migration writes a .migrated_to breadcrumb at the old root."""
+    src = tmp_path / "old"
+    dst = tmp_path / "new"
+    _make_old_tree(src)
+
+    result = _migrate_tree(src, dst, force=False, is_cross_volume=lambda *_: False)
+
+    assert result.status == "migrated"
+    breadcrumb = src / ".migrated_to"
+    assert breadcrumb.exists(), "breadcrumb file must exist after migration"
+    contents = breadcrumb.read_text().strip()
+    assert contents == str(dst.resolve())
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_idempotent_via_breadcrumb(tmp_path: Path, monkeypatch) -> None:
+    """Second migrate() call returns skipped_already_migrated for migrated roots."""
+    # Build an old cache tree and mark it as already migrated.
+    old_root = tmp_path / ".raw_data"
+    _make_old_tree(old_root)
+    new_root = tmp_path / "cache"
+    (old_root / ".migrated_to").write_text(f"{new_root.resolve()}\n")
+
+    # Redirect the scanner to only find our tmp tree.
+    monkeypatch.setattr(
+        "oda_data.cache._migrate._old_cache_paths_to_scan", lambda: [old_root]
+    )
+    monkeypatch.setattr("oda_data.cache._migrate.oda_data_cache_root", lambda: new_root)
+
+    results = migrate()
+
+    assert len(results) == 1
+    assert results[0].status == "skipped_already_migrated"
+
+
+# ---------------------------------------------------------------------------
+# Disk-full
+# ---------------------------------------------------------------------------
+
+
+def test_disk_full_logs_warning(tmp_path: Path, caplog) -> None:
+    """Disk-full OSError (errno 28) logs a WARNING and does not propagate."""
+    src = tmp_path / "old"
+    dst = tmp_path / "new"
+    _make_old_tree(src)
+
+    disk_full = OSError(errno.ENOSPC, "No space left on device")
+
+    # The "oda_data" logger has propagate=False, so caplog's root handler doesn't
+    # see records on its descendant loggers. Attach caplog.handler directly.
+    _od_logger = logging.getLogger("oda_data")
+    _od_logger.addHandler(caplog.handler)
+    try:
+        with (
+            caplog.at_level(logging.WARNING),
+            patch("oda_data.cache._migrate.shutil.move", side_effect=disk_full),
+        ):
+            result = _migrate_tree(
+                src, dst, force=False, is_cross_volume=lambda *_: False
+            )
+
+        assert result.status == "skipped_disk_full"
+        assert result.files_moved == 0
+        assert any("Disk full" in r.message for r in caplog.records)
+    finally:
+        _od_logger.removeHandler(caplog.handler)
+
+    # Both trees should still be present (old has data, new may be empty dir).
+    src_files = list(src.rglob("*.parquet"))
+    assert src_files, "source files must remain after disk-full"
+
+
+# ---------------------------------------------------------------------------
+# migrate() returns list[MigrationResult]
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_returns_list_of_results(tmp_path: Path, monkeypatch) -> None:
+    """migrate() returns a list of MigrationResult instances."""
+    old1 = tmp_path / ".raw_data"
+    old2 = tmp_path / "Library" / "Caches" / "oda-reader"
+    for d in (old1, old2):
+        _make_old_tree(d)
+
+    new_root = tmp_path / "cache"
+
+    monkeypatch.setattr(
+        "oda_data.cache._migrate._old_cache_paths_to_scan", lambda: [old1, old2]
+    )
+    monkeypatch.setattr("oda_data.cache._migrate.oda_data_cache_root", lambda: new_root)
+
+    results = migrate()
+
+    assert len(results) == 2
+    assert all(isinstance(r, MigrationResult) for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Auto-migration laziness
+# ---------------------------------------------------------------------------
+
+
+def test_auto_migration_lazy(monkeypatch, tmp_path) -> None:
+    """migrate() is not called at import; called exactly once on first cache access."""
+    import oda_data.cache.config as cfg
+
+    migrate_calls: list[bool] = []
+
+    def fake_auto_migrate() -> None:
+        """Drop-in for _auto_migrate_once that records invocations."""
+        if cfg._AUTO_MIGRATED:
+            return
+        cfg._AUTO_MIGRATED = True
+        migrate_calls.append(False)
+
+    # Reset flag and install the spy.
+    monkeypatch.setattr(cfg, "_AUTO_MIGRATED", False)
+    monkeypatch.setattr(cfg, "_auto_migrate_once", fake_auto_migrate)
+
+    # migrate should not have been called yet (import alone does not trigger).
+    assert migrate_calls == []
+
+    # First call to _auto_migrate_once executes migration.
+    cfg._auto_migrate_once()
+    assert len(migrate_calls) == 1
+
+    # Second call is a no-op — flag is already True.
+    cfg._auto_migrate_once()
+    assert len(migrate_calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# F-3: _auto_migrate_once exception policy
+# ---------------------------------------------------------------------------
+
+
+def _raises_oserror(*, force: bool = False) -> None:
+    raise OSError("boom")
+
+
+def _raises_runtime(*, force: bool = False) -> None:
+    raise RuntimeError("downgrade")
+
+
+def test_auto_migrate_once_swallows_oserror(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """_auto_migrate_once swallows OSError from migrate and logs a WARNING.
+
+    Patches the source of the local import so the monkeypatch is effective
+    regardless of when the local 'from ... import migrate as _do_migrate'
+    executes inside _auto_migrate_once.
+    """
+    import oda_data.cache.config as cfg
+
+    # Explicit reset — guards against flag leakage until Slice C autouse lands.
+    monkeypatch.setattr(cfg, "_AUTO_MIGRATED", False)
+    monkeypatch.setattr("oda_data.cache._migrate.migrate", _raises_oserror)
+
+    # The "oda_data" logger has propagate=False; attach caplog.handler directly.
+    _od_logger = logging.getLogger("oda_data")
+    _od_logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.WARNING):
+            cfg._auto_migrate_once()  # must not raise
+
+        warning_messages = [
+            r.message for r in caplog.records if r.levelno == logging.WARNING
+        ]
+        assert any("auto-migration failed" in m for m in warning_messages), (
+            f"Expected a WARNING containing 'auto-migration failed'; got: {warning_messages}"
+        )
+    finally:
+        _od_logger.removeHandler(caplog.handler)
+
+
+def test_auto_migrate_once_propagates_runtimeerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """_auto_migrate_once propagates RuntimeError (downgrade-detection signal)."""
+    import oda_data.cache.config as cfg
+
+    # Explicit reset — guards against flag leakage until Slice C autouse lands.
+    monkeypatch.setattr(cfg, "_AUTO_MIGRATED", False)
+    monkeypatch.setattr("oda_data.cache._migrate.migrate", _raises_runtime)
+
+    with pytest.raises(RuntimeError, match="downgrade"):
+        cfg._auto_migrate_once()

--- a/tests/migration/test_multiprocess_race.py
+++ b/tests/migration/test_multiprocess_race.py
@@ -1,0 +1,108 @@
+"""Multi-process race test for bulk-cache FileLock serialisation.
+
+The fake fetcher is defined at module scope so it pickles cleanly under
+``multiprocessing.get_context("spawn")``.
+"""
+
+from __future__ import annotations
+
+import io
+import multiprocessing as mp
+import os
+import time
+import zipfile
+from pathlib import Path
+
+import pytest
+
+# Guard: slice (b)/(c) must land before this test can run.
+pytest.importorskip(
+    "oda_data.cache",
+    reason="requires slices (b)/(c): oda_data.cache not yet available",
+)
+
+# ---------------------------------------------------------------------------
+# Module-scope fake fetcher — must live here so spawn workers can pickle it.
+# ---------------------------------------------------------------------------
+
+# Initialised by the pool initializer; stays None until workers start.
+_COUNTER: mp.sharedctypes.Synchronized[int] | None = None  # type: ignore[assignment]
+
+
+def _slow_fetcher(target_path: Path) -> None:
+    """Write a 1 KB valid zip and increment the shared counter.
+
+    Sleeps 200 ms to make concurrent calls overlap, maximising the chance
+    of a race condition if FileLock is not held correctly.
+
+    Args:
+        target_path: Destination path for the fake zip.
+    """
+    time.sleep(0.2)
+    if _COUNTER is not None:
+        with _COUNTER.get_lock():
+            _COUNTER.value += 1
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("crs.parquet", b"PAR1" + b"\x00" * 1000)
+    target_path.write_bytes(buf.getvalue())
+
+
+def _init_worker(counter: mp.sharedctypes.Synchronized[int], cache_root: Path) -> None:
+    """Pool initialiser — sets per-worker globals before the first task runs.
+
+    Args:
+        counter: Shared integer counter tracking fetch invocations.
+        cache_root: Path to the temporary cache root; written to
+            ODA_DATA_CACHE_DIR so each worker uses the shared temp dir.
+    """
+    global _COUNTER
+    _COUNTER = counter
+    os.environ["ODA_DATA_CACHE_DIR"] = str(cache_root)
+
+
+def _worker_call(_unused: int) -> None:
+    """Worker task: call BulkCacheManager.ensure with a slow fake fetcher.
+
+    Drives the cache-manager layer directly so we exercise the FileLock
+    serialisation contract without going through the network-discovery layer.
+
+    Args:
+        _unused: Pool.map index; not used.
+    """
+    from pathlib import Path
+
+    from oda_data.tools.cache import BulkCacheEntry, BulkCacheManager
+
+    cache_root = Path(os.environ["ODA_DATA_CACHE_DIR"])
+    mgr = BulkCacheManager(cache_root / "oda-data")
+    entry = BulkCacheEntry(key="CRSData_bulk", fetcher=_slow_fetcher, ttl_days=30)
+    mgr.ensure(entry)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def test_four_workers_one_fetch(tmp_path: Path) -> None:
+    """Four concurrent workers trigger exactly one network fetch (FileLock test)."""
+    ctx = mp.get_context("spawn")
+    counter = ctx.Value("i", 0)
+    # Set ODA_DATA_CACHE_DIR before pool start so spawned children inherit it via
+    # the environment copy that spawn makes for each new process.
+    prev = os.environ.get("ODA_DATA_CACHE_DIR")
+    os.environ["ODA_DATA_CACHE_DIR"] = str(tmp_path)
+    try:
+        with ctx.Pool(
+            4, initializer=_init_worker, initargs=(counter, tmp_path)
+        ) as pool:
+            pool.map(_worker_call, range(4))
+    finally:
+        if prev is None:
+            os.environ.pop("ODA_DATA_CACHE_DIR", None)
+        else:
+            os.environ["ODA_DATA_CACHE_DIR"] = prev
+    assert counter.value == 1, (
+        f"Expected exactly 1 fetch across 4 workers, got {counter.value}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -407,11 +407,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.20.1"
+version = "3.29.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a7/23/ce7a1126827cedeb958fc043d61745754464eb56c5937c35bbf2b8e26f34/filelock-3.20.1.tar.gz", hash = "sha256:b8360948b351b80f420878d8516519a2204b07aefcdcfd24912a5d33127f188c", size = 19476, upload-time = "2025-12-15T23:54:28.027Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/7f/a1a97644e39e7316d850784c642093c99df1290a460df4ede27659056834/filelock-3.20.1-py3-none-any.whl", hash = "sha256:15d9e9a67306188a44baa72f569d2bfd803076269365fdea0934385da4dc361a", size = 16666, upload-time = "2025-12-15T23:54:26.874Z" },
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
 ]
 
 [[package]]
@@ -628,6 +628,64 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/16/5a/c8bc268ae5b6dbab4db01d92f9d34713a7c487bc85f2522173cf24bc5c74/imf_reader-1.4.1.tar.gz", hash = "sha256:2584e45485b539cd2d15bf0a785e6ac5f29775c042d9d5f83c7af5d5f0947c0b", size = 13271, upload-time = "2025-12-05T11:41:01.049Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/79/97bd7b6c3af609b33ba2d787ea9e06ad93b1deca38388a345b6c913825ea/imf_reader-1.4.1-py3-none-any.whl", hash = "sha256:16c0dafcbe0e6630e7d3adbccb81e828b3e971b79e3969b79fbd6772151165c5", size = 19285, upload-time = "2025-12-05T11:41:00.218Z" },
+]
+
+[[package]]
+name = "inflate64"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/f3/41bb2901543abe7aad0b0b0284ae5854bb75f848cf406bf8a046bf525f67/inflate64-1.0.4.tar.gz", hash = "sha256:b398c686960c029777afc0ed281a86f66adb956cfc3fbf6667cc6453f7b407ce", size = 902542, upload-time = "2025-11-28T10:55:52.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/e4/2fc07d71cf863ed4167e7d3eb7f89de0341ffe3ed3a62ff6cc4123bdbda6/inflate64-1.0.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:bccda9815b27623e805a34ee3ee4f46c93f0cc7ac621f9834d75f033fd79c27a", size = 58595, upload-time = "2025-11-28T10:54:34.338Z" },
+    { url = "https://files.pythonhosted.org/packages/53/77/1119bb53e8f4c9c77f2a5e3ab7d8c3e905fcfc9912073962b9b4cbf72118/inflate64-1.0.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c11e2a3cb9d9b49620c9b0c806dd0c55daec3b6bb665299b770a68f01bfc5432", size = 35854, upload-time = "2025-11-28T10:54:35.796Z" },
+    { url = "https://files.pythonhosted.org/packages/de/40/8b028a731f6fabbb49069a58f1aa5c3332688b57dcb8726f9e596661ce5b/inflate64-1.0.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e42def03ace8c58fd50b0df4f40241c45a2314c3876d020cce24acf958323c98", size = 36011, upload-time = "2025-11-28T10:54:37.208Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a3/5b67ef7fd5e7546d4c2be8a9a869c70d9fd525de1cfb2b4dc4b0855eeee8/inflate64-1.0.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7912927a509ca58d1a445ce4ff6e6e9f276dc1d72687386cdf7103bf590e785c", size = 98112, upload-time = "2025-11-28T10:54:38.616Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6e/6443ea6c42f6b244c4e59cb43f16e6b903669f718a96e3f1985acf473dea/inflate64-1.0.4-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ec40c0383cbd84d845dcb785a48ae76eef43246c923f84fda380fdd5ea653d3c", size = 99549, upload-time = "2025-11-28T10:54:40.167Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ce/e98577e0771b857b491a64a3f7495eb507e0752b80093068b69813088df1/inflate64-1.0.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:5b01539fea372c6078b9707d9121c12cb321e587e193f50e257ce06cf5b15e41", size = 95946, upload-time = "2025-11-28T10:54:41.318Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/3e/8165ff4051dff08b2cc8448dafd15a697564e84cf40f3ee0dc0df16eed16/inflate64-1.0.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:bf4e34e32a37a42e9cf8bd9681f89e3e37b218f97d8b8cc95bd065419bc8db13", size = 98766, upload-time = "2025-11-28T10:54:43.366Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b8/20cad309ded1d97195c5ad50e341b38ddc2e82f5c44ee7d000c4372c8b56/inflate64-1.0.4-cp311-cp311-win32.whl", hash = "sha256:2725ccc14b138f0ad622d0322b769f177f9edfe016ee9ed3404102935d39e7de", size = 32939, upload-time = "2025-11-28T10:54:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/32/be5cac018960157d33d61278377d590d5cc34922222cb0c4dc3284ce6eeb/inflate64-1.0.4-cp311-cp311-win_amd64.whl", hash = "sha256:7056148548c1f25dcb38251f88c19b4635a5f32af4c7bad00621c85509e3d8c0", size = 35535, upload-time = "2025-11-28T10:54:46.214Z" },
+    { url = "https://files.pythonhosted.org/packages/13/36/9b130e45299d587f306178d65e950e1c8f60a09db8bb55c7cdce8fdda3b6/inflate64-1.0.4-cp311-cp311-win_arm64.whl", hash = "sha256:2ea7bdcad65e255b4596f84880f6e0c1756d6336d620e302653257defa407742", size = 33457, upload-time = "2025-11-28T10:54:47.258Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/33/5cfa7468960de1be0833e7e41adf5b7804a0aef2fb46f3679df3876bf3ab/inflate64-1.0.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:c8009e4a4918ee6c8cbc49e58fe159464895064cfdf0565fed3f49ca81e45272", size = 58619, upload-time = "2025-11-28T10:54:48.315Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/0a/583c7c2832da36e986c5758d0afb6f5944599e55c5b798b066a9ef63e581/inflate64-1.0.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0d173a7a0e865bb7d19685c5b1ad2994712b8361b24136d7e94abeff58505647", size = 35865, upload-time = "2025-11-28T10:54:49.389Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4b/9c6acfbe900e5c8698132244c68036b0455bd2169f46e356c83dc0366f11/inflate64-1.0.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8bad992f2d034f5f7e36208e54502d1b0829ce772c898e5dc59109833420148a", size = 36019, upload-time = "2025-11-28T10:54:50.813Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/66/c0c3d3b4b863aab2c2ce631d219a8eb3b95b78acd5f40d3212f071e693db/inflate64-1.0.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6bfcf806912ced77a21394f7363805ecacd626b79f93cba87d505a48e88ede78", size = 98765, upload-time = "2025-11-28T10:54:52.273Z" },
+    { url = "https://files.pythonhosted.org/packages/37/00/1a2351a85d36b26c5b2b8cfbb37ad86084c98f592dd7590f8577d8b33993/inflate64-1.0.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62d1aac3aba094ae42e27ce7581b414c90f218248be0953b6aeb11a127225e5d", size = 100594, upload-time = "2025-11-28T10:54:53.684Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/3e/5d18ff5b86aaaf54117e1bb6ce15cb17163f56035f9c480e609d35f258ab/inflate64-1.0.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8065166f355122484f004225b379d403346bdae69ec624786a9334f025580675", size = 96745, upload-time = "2025-11-28T10:54:55.277Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ff/306d5d6aca1e04e596d2a504a59ff9a900623a6ec852f38aab99f384562d/inflate64-1.0.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:94a95f32087d223d2e119ff5c7c264109e8d4cb7e421e7a688a899a6fe021b38", size = 99795, upload-time = "2025-11-28T10:54:56.485Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/ec/d4caa4bf3c9e520c15e900fee5a00fc523953843e14aa378ca1abfb2b4ea/inflate64-1.0.4-cp312-cp312-win32.whl", hash = "sha256:ad4fa490bb7dc2a4640a3adaa2d5950f4a465ba034bbcf184c2103646e58ad97", size = 32956, upload-time = "2025-11-28T10:54:57.642Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c4/c0de4e9bdf12e449360b710e9ab5b5248804610f382b538773cbd07b72bb/inflate64-1.0.4-cp312-cp312-win_amd64.whl", hash = "sha256:2c6befdf83d088a6e0d10d0873a9d4bfde2ce00ad7a52c8189cf303306f98030", size = 35577, upload-time = "2025-11-28T10:54:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/03a5ef74ad3869b3c5af3b09216321f5a1a5a45265f7bd6d5abc669c7622/inflate64-1.0.4-cp312-cp312-win_arm64.whl", hash = "sha256:2b263c619469f90a75f29c421c53d31b208ad494a078235a8f6db2bc96583fdc", size = 33465, upload-time = "2025-11-28T10:55:00.568Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/55/b7de7ae318a4f233f892c4f7c8b7e0e8643abe3fdcc53ed35020a9fe3f47/inflate64-1.0.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:c3f37540d0e64884a935fd62a7d17e40ab69f05ec63e815483b6513675d01bef", size = 58633, upload-time = "2025-11-28T10:55:01.931Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/5f/6f89c8524503fd7a9ca2bd91fe60d7291b3f684e9d41edb38ef49e10fc3d/inflate64-1.0.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4d24112180c95d12f279cade9a1e21f8be7f4790c4109c293292edf87d061992", size = 35864, upload-time = "2025-11-28T10:55:03.075Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/14/9eadd59244b38cf85ccd0ca43d1296c50b3a33aa37be4fb68a1928efa58c/inflate64-1.0.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5c098dab17821f466fc6e6a3d78fc6e0295bb51458015f03416b1d58d6a8df4f", size = 36019, upload-time = "2025-11-28T10:55:04.126Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/04/399e82d8f5003dd92c8a0c5c1a9a8ce0919114710a496cbe88848bff3a72/inflate64-1.0.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a984b9287ff0fb596eb058d66a9e94530556afd2b7c054b44f2e0aeeff894e8f", size = 98973, upload-time = "2025-11-28T10:55:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c5/038dc2593bbc4272d87eac8c9f75692267d47f834ced888f6d81995df606/inflate64-1.0.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f62a13d0327631778fa2a47c308ae2b07b2659b7bb8564783259ac65949f8c0c", size = 100777, upload-time = "2025-11-28T10:55:06.41Z" },
+    { url = "https://files.pythonhosted.org/packages/74/4a/f6d3031dd3578510894a41bfe1ac149228970ce1629a43f20e0c5abbe8d1/inflate64-1.0.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:513201336fb3b0b7e2aee5dbbbe30a9f1b23291738b5ceb80076fc285f2ec2f1", size = 96967, upload-time = "2025-11-28T10:55:07.594Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ef/7ab3bde4e176609ae0e607a8a9bb38d201885275664a6d574299f5bf7850/inflate64-1.0.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:84ce3a97272ba745fce52b38363855c7201968f6402a794bbade774e64c657b9", size = 99997, upload-time = "2025-11-28T10:55:08.85Z" },
+    { url = "https://files.pythonhosted.org/packages/39/59/8256b3e802e203c8645e0b32b25e6bd94508ad572593f0cdf8234db3879a/inflate64-1.0.4-cp313-cp313-win32.whl", hash = "sha256:332051a9d7e50579b90a3f555d68f53414b06f636c9ffe82e97c0baae3c8fbcc", size = 32958, upload-time = "2025-11-28T10:55:10.343Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4f/5784ee1eb8260f2310e24ef2883f1f494f9332bcfde4ed14ee780372149e/inflate64-1.0.4-cp313-cp313-win_amd64.whl", hash = "sha256:3983f53b590ff7d0ba243f664ce852aca882482f30f7a8eab33e10d769336d0c", size = 35578, upload-time = "2025-11-28T10:55:11.389Z" },
+    { url = "https://files.pythonhosted.org/packages/39/e8/8d927770ce25dc9764c8104207a80653d65471d0a6a8f9ead350016e4586/inflate64-1.0.4-cp313-cp313-win_arm64.whl", hash = "sha256:118d8286f085e99a14341c76ef9fbffd56619ccc80318a9a204aea3dbfa71470", size = 33465, upload-time = "2025-11-28T10:55:12.824Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/fb/ec9d10f44f2fc7666ad5d70acae2b8a1941e8e08ccae1fad0820f7796be3/inflate64-1.0.4-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:4f61925b2d4248eac2ebb15350a80aaa0d1f7f1dc770bd5ebbbb3b0db4a6a416", size = 58727, upload-time = "2025-11-28T10:55:13.834Z" },
+    { url = "https://files.pythonhosted.org/packages/81/80/24ba0d2ee14e07e275e9c5b058e59a8a58f8ef42dd51a78ebbfd7c857ac4/inflate64-1.0.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c1acf18b08b32981a4a11ec5a112b8ad5d7c7a5b15cb5bdbdb5b19201e9aa180", size = 35945, upload-time = "2025-11-28T10:55:15.225Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b8/073a79716e093db973b8823bdfb02e10fbdf65642dbe1fa3cda24832aeb2/inflate64-1.0.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:abddae8920b2eaef824254e14b8d4ff54afbe6194a1bbe9816584859f0c1244d", size = 36060, upload-time = "2025-11-28T10:55:16.261Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/f0/87d3c317ed0acd94f5e9b3b1b9e9000228ea2af0cb4618c62cbfc816da34/inflate64-1.0.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b303132cc562a906543a56f35c4e164e3880da6ff041cb4a7b1df9f9d2b4bb69", size = 98995, upload-time = "2025-11-28T10:55:17.405Z" },
+    { url = "https://files.pythonhosted.org/packages/90/72/0b6035302e9c33f004240a50cb6e2e1fc7bb1f2b415b02d939c551bdd06b/inflate64-1.0.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f0993214dea0738c557fa56c13cd9083aef0097a201d726c21984ad7f577514", size = 100781, upload-time = "2025-11-28T10:55:18.597Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/05/5f383c615ec0f01bcbbc699a71da167623e494083ab7ed0df86b4bddf125/inflate64-1.0.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a6baedc3288d7a4ff588951d3a9a97a5391dceed6255ff5b16e42cae7274bfa9", size = 97038, upload-time = "2025-11-28T10:55:20.156Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9a/c1482718c717c49c67490c42b4fdced9476e894eaebd52193e488c12e188/inflate64-1.0.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a846ce1f38845b20bef2625af1b512be83416d97824539524c5a34e7a729aec7", size = 100016, upload-time = "2025-11-28T10:55:21.337Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7f/700ede7474e72a1c0e2e8fe36624cd0225ca8b2875eca33d64aa2de75f4d/inflate64-1.0.4-cp314-cp314-win32.whl", hash = "sha256:eef87908c780439393d577a155868317f0a275b47b417db9f47d8633ec791745", size = 33691, upload-time = "2025-11-28T10:55:22.515Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/51/f2972df8cceecc9bf3afa3353d517ffc7125285198c844588e9aaf98f5d0/inflate64-1.0.4-cp314-cp314-win_amd64.whl", hash = "sha256:fb2fdd63ef3933b67af98b3f2ee2f57e7787278041d7ba4821382fedd729b68a", size = 36304, upload-time = "2025-11-28T10:55:24.005Z" },
+    { url = "https://files.pythonhosted.org/packages/29/77/16200aced67215119fb30ec9a5889b48289ee2fa5ce5137623a9ad41b2c4/inflate64-1.0.4-cp314-cp314-win_arm64.whl", hash = "sha256:2e129669a0243ac7816fd526946ee01c25688fe81623a6d6bc95b3156d80f4fb", size = 34491, upload-time = "2025-11-28T10:55:25.068Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/79/b466ec7666c40912ea81a305a8a2b75f5998e6cec1d3d75e067d76203731/inflate64-1.0.4-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:b17bf665d948dc4edeea0cd17752415d0cd7240c882b9c7e136ad4cc4321e9d4", size = 59300, upload-time = "2025-11-28T10:55:26.185Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ad/16e1168ac80f39894e6cb18b439eec63fec42cbced239aebfe12081b6ec7/inflate64-1.0.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:6751758301936fbb38fa38eb5312e14e27b6a1abf568f83c17557fab2694373d", size = 36258, upload-time = "2025-11-28T10:55:27.295Z" },
+    { url = "https://files.pythonhosted.org/packages/25/42/c463b42fd8a7947b4445fbaf57c265bb7f3114362fb7aee6884ffd8b5341/inflate64-1.0.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d6a4136752aa2a544301059d8f13780aeb88c34d60770258436a87dacd3fc304", size = 36296, upload-time = "2025-11-28T10:55:28.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/f1/cf6121926e405020e9e7bccb78ec7781fbc87500ec67368e7d9e866758be/inflate64-1.0.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:938ebc6b28578bfd365d1a9fdb18b7faab08321babeb2198e8025d07d8dc7fb5", size = 106788, upload-time = "2025-11-28T10:55:29.797Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/dd/b653f9962497cf4d3520d69272894c37fd76f86a0e04bb3bd9f32827dc2f/inflate64-1.0.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:61f51f80fa6f367288343c1a2cd20a42af454883087064e9274fd2a8c3a5a200", size = 107959, upload-time = "2025-11-28T10:55:31.306Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ae/65d88109b63611c9b6c29008201107127cf2603d186ab99beec39d85f38e/inflate64-1.0.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:172b51da7bbfa66b33f0a5405e944807b9949e92cf4cd9f983c07af8152766df", size = 104213, upload-time = "2025-11-28T10:55:32.506Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/94/c17de2f55b9fb1269bca4657f9089efe4ba0f3d4b652f07b34dfc69f69a2/inflate64-1.0.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8ca9a2985afd5a14fb48cd126a67e5944ccb7a0a6bdec58c4f796c8c88a84539", size = 106629, upload-time = "2025-11-28T10:55:33.735Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/30/8bbc587bb2ad09ab7edf1f9215b2c5faf4fa7ee7c071daefe9ed55e28814/inflate64-1.0.4-cp314-cp314t-win32.whl", hash = "sha256:f8964ceaabea294bc20abc9ef408c6aae978a75c25c83168a76cd87a37c38938", size = 33865, upload-time = "2025-11-28T10:55:35.335Z" },
+    { url = "https://files.pythonhosted.org/packages/91/87/8bf6f412f93c8b6dc14866a021b83321331fbdd17f6ab902a24dbf88773d/inflate64-1.0.4-cp314-cp314t-win_amd64.whl", hash = "sha256:7d13b04cba65c12d21e65eaa77da9484e265e8e821b26e0761d1455ad3a878d9", size = 36943, upload-time = "2025-11-28T10:55:36.983Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/85/33447bb3c4e3c0ae7b1fde3aadc52a18b2b0193cfcf4f585977e924c6463/inflate64-1.0.4-cp314-cp314t-win_arm64.whl", hash = "sha256:9ae3ee727235a06dc3cd353ee5761fdd8e3b56ad119c711f61680528972a6ced", size = 34846, upload-time = "2025-11-28T10:55:38.433Z" },
 ]
 
 [[package]]
@@ -1163,13 +1221,14 @@ wheels = [
 
 [[package]]
 name = "oda-data"
-version = "2.5.0"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
     { name = "filelock" },
     { name = "oda-reader" },
     { name = "pandas", extra = ["excel", "parquet", "performance"] },
+    { name = "platformdirs" },
     { name = "pydeflate" },
     { name = "reader" },
     { name = "thefuzz" },
@@ -1194,8 +1253,9 @@ test = [
 requires-dist = [
     { name = "cachetools", specifier = ">=6.2.0" },
     { name = "filelock", specifier = ">=3.20.0" },
-    { name = "oda-reader", specifier = ">=1.4.1" },
+    { name = "oda-reader", specifier = ">=1.6.0" },
     { name = "pandas", extras = ["excel", "parquet", "performance"], specifier = ">=2.2.0" },
+    { name = "platformdirs", specifier = ">=4.0.0" },
     { name = "pydeflate", specifier = ">=2.3.3" },
     { name = "reader", specifier = ">=3.18" },
     { name = "thefuzz", specifier = ">=0.22.1" },
@@ -1218,10 +1278,11 @@ test = [
 
 [[package]]
 name = "oda-reader"
-version = "1.4.1"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
+    { name = "inflate64" },
     { name = "joblib" },
     { name = "openpyxl" },
     { name = "pandas" },
@@ -1230,9 +1291,9 @@ dependencies = [
     { name = "requests" },
     { name = "requests-cache" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/bb/69a6d5fb1165c565e5dde9db387a959932416291235224987c034ac0a1b2/oda_reader-1.4.1.tar.gz", hash = "sha256:cfff97e144ddc69c50e6edaf3d7782c3bf6561960208482ab166f47d94ef0cac", size = 44827, upload-time = "2025-12-19T16:37:00.029Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/08/93bd4f4092cec3de4b3010a12d16c445ee83f452317c0f66aaf577faa621/oda_reader-1.6.0.tar.gz", hash = "sha256:30bf38fc247d02a9d296d9022aebd3f2db8537ff9daeddf11a8a16d274da108e", size = 52780, upload-time = "2026-04-29T02:42:00.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/93/4d10495a0517d7e237cd39dc96e8891f04d560610726d5111e85a909d79d/oda_reader-1.4.1-py3-none-any.whl", hash = "sha256:ac464690026c9cd63bf36a1c82b7111da13f87066becd04ff01d86bd52d36a76", size = 61157, upload-time = "2025-12-19T16:36:58.98Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/9b/0316a8f5edd2736f6570515c34c3946c877a00dc9fe00dda28cf2e4bd84b/oda_reader-1.6.0-py3-none-any.whl", hash = "sha256:69b8e513691d4cef7de871c76a88f27ddd8840f9860e8bc092d03ff9cd79fa22", size = 71087, upload-time = "2026-04-29T02:41:59.616Z" },
 ]
 
 [[package]]
@@ -2027,7 +2088,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.5"
+version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -2035,9 +2096,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces major improvements to how `oda_data` manages its caching system, providing a more robust, user-friendly, and transparent cache management experience. The cache is now stored in a standard per-user, per-version directory, with a unified API for inspecting, clearing, and migrating cache data. Existing caches are automatically migrated on first use, and new documentation thoroughly explains all cache operations, recovery, and migration scenarios.

**Key changes include:**

### New cache system and user API

* Introduced a detailed `CACHING.md` guide documenting the new cache system, including cache locations, configuration, Python API (`oda_data.cache`), migration from older versions, recovery from corrupt cache, and multi-process behavior. The document also covers legacy compatibility for standalone `oda_reader` users.
* Added a new `oda_data.cache` namespace, providing type-safe, granular cache management functions (`size`, `clear`, `invalidate`, `enable_cache`, `disable_cache`, `migrate`, etc.) and allowing per-scope operations for advanced workflows.
* The cache now defaults to a per-user, per-version directory determined by the OS, with override capability via `set_cache_root()` or the `ODA_DATA_CACHE_DIR` environment variable. [[1]](diffhunk://#diff-924c6cd435d4d9746f12971cd4baef64d9236ae6fe2a43d4297affdd1d2a8873R1-R384) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L420-R442)

### Documentation and user guidance

* Updated the main `README.md` to describe the new cache behavior, including how to recover from corrupt caches and the relationship between legacy helpers and the new API.
* Added and updated changelogs (`CHANGELOG.md`, `docs/docs/changelog.md`) with detailed release notes for version 2.6.0, summarizing the new cache system, migration process, API changes, and backward compatibility. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R72) [[2]](diffhunk://#diff-09e59dfec1d3fe554796ca3fe446e6e3f4076334ab224561ff3899b3c17b3e6cR8-R132)

### Backward compatibility and migration

* Existing cache management helpers (`clear_cache`, `enable_cache`, `disable_cache`) are preserved as thin wrappers over the new API, ensuring seamless upgrades for existing scripts. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L420-R442) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R72) [[3]](diffhunk://#diff-09e59dfec1d3fe554796ca3fe446e6e3f4076334ab224561ff3899b3c17b3e6cR8-R132)
* Automatic migration of caches from pre-2.6 locations to the new layout, with clear logging and manual override for special cases (e.g., synced drives, disk full). [[1]](diffhunk://#diff-924c6cd435d4d9746f12971cd4baef64d9236ae6fe2a43d4297affdd1d2a8873R1-R384) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R72) [[3]](diffhunk://#diff-09e59dfec1d3fe554796ca3fe446e6e3f4076334ab224561ff3899b3c17b3e6cR8-R132)

These changes significantly improve cache reliability, transparency, and user control, making cache management easier and safer for all `oda_data` users.

**References:** [[1]](diffhunk://#diff-924c6cd435d4d9746f12971cd4baef64d9236ae6fe2a43d4297affdd1d2a8873R1-R384) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L420-R442) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R72) [[4]](diffhunk://#diff-09e59dfec1d3fe554796ca3fe446e6e3f4076334ab224561ff3899b3c17b3e6cR8-R132)